### PR TITLE
NiveaShop - updated logs with buyer reference app and mystore

### DIFF
--- a/logs/NiveaShop/BuyerAppPreProdLogs/cancel.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/cancel.json
@@ -1,0 +1,38 @@
+{
+    "_id": {
+      "$oid": "63441a5154e61494687f1484"
+    },
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "store": {
+      "$oid": "62b42dc426b83e2a358464e2"
+    },
+    "action": "cancel",
+    "context": {
+      "domain": "nic2004:52110",
+      "country": "IND",
+      "city": "std:080",
+      "action": "cancel",
+      "core_version": "1.0.0",
+      "bap_id": "buyer-app-preprod.ondc.org",
+      "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+      "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+      "message_id": "0ace066c-b72c-4192-a019-31402ae1ded5",
+      "timestamp": "2022-10-10T13:12:49.141Z",
+      "bpp_id": "ondc.niveashop.in"
+    },
+    "message": {
+      "order_id": "31cc2734-807c-4af2-bdf2-df142135b02d",
+      "cancellation_reason_id": "001"
+    },
+    "createdAt": {
+      "$date": {
+        "$numberLong": "1665407569572"
+      }
+    },
+    "updatedAt": {
+      "$date": {
+        "$numberLong": "1665407569572"
+      }
+    },
+    "__v": 0
+  }

--- a/logs/NiveaShop/BuyerAppPreProdLogs/confirm.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/confirm.json
@@ -1,0 +1,142 @@
+{
+  "_id": {
+    "$oid": "6344198f54e61494687f1445"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "confirm",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "confirm",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "e7e5d087-de5b-4a4a-bd9e-f95799ba84d1",
+    "timestamp": "2022-10-10T13:09:34.440Z",
+    "bpp_id": "ondc.niveashop.in"
+  },
+  "message": {
+    "order": {
+      "id": "31cc2734-807c-4af2-bdf2-df142135b02d",
+      "billing": {
+        "address": {
+          "door": "modi kirana",
+          "name": "Agam Dubey",
+          "building": "modi kirana",
+          "street": "my street",
+          "locality": "Agam Dubey",
+          "city": "Bilaspur",
+          "country": "IND",
+          "area_code": "495001"
+        },
+        "phone": "9399452347",
+        "name": "Agam Dubey",
+        "email": "agam.dubey@schbang.com"
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "locations": [
+          {
+            "id": "62b42dc426b83e2a358464e2"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "contact": {
+              "email": "agam.dubey@schbang.com",
+              "phone": "9399452347"
+            },
+            "location": {
+              "gps": "22.0884760000001, 82.1389140000001",
+              "address": {
+                "door": "modi kirana",
+                "name": "agam.dubey",
+                "building": "modi kirana",
+                "street": "my street",
+                "locality": "Agam Dubey",
+                "city": "Bilaspur",
+                "country": "IND",
+                "area_code": "495001"
+              }
+            }
+          },
+          "type": "Delivery",
+          "customer": {
+            "person": {
+              "name": "agam.dubey"
+            }
+          },
+          "provider_id": "62b42dc426b83e2a358464e2"
+        }
+      ],
+      "addOns": [],
+      "offers": [],
+      "payment": {
+        "params": {
+          "amount": "330",
+          "currency": "INR",
+          "transaction_id": "ONDC-426281de-010b-4d23-8fb1-77661e37be68-1"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330"
+        },
+        "breakup": [
+          {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "@ondc/org/item_id": "43001177440483",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "255.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
+          }
+        ],
+        "ttl": "P24H"
+      }
+    }
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407375258"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407375258"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/init.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/init.json
@@ -1,0 +1,112 @@
+{
+  "_id": {
+    "$oid": "6344197a54e61494687f1421"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "init",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "init",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "2d28e536-5681-4c70-a408-e17b5e0f1e36",
+    "timestamp": "2022-10-10T13:09:13.862Z",
+    "bpp_id": "ondc.niveashop.in"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "locations": [
+          {
+            "id": null
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "add_ons": [],
+      "offers": [],
+      "billing": {
+        "address": {
+          "door": "modi kirana",
+          "name": "Agam Dubey",
+          "building": "modi kirana",
+          "street": "my street",
+          "locality": null,
+          "ward": null,
+          "city": "Bilaspur",
+          "state": "Chhattisgarh",
+          "country": "IND",
+          "areaCode": "495001",
+          "area_code": "495001"
+        },
+        "phone": "9399452347",
+        "name": "Agam Dubey",
+        "email": "agam.dubey@schbang.com"
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "contact": {
+              "email": "agam.dubey@schbang.com",
+              "phone": "9399452347"
+            },
+            "location": {
+              "gps": "22.0884760000001, 82.1389140000001",
+              "address": {
+                "door": "modi kirana",
+                "name": "Agam Dubey",
+                "building": "modi kirana",
+                "street": "my street",
+                "locality": null,
+                "ward": null,
+                "city": "Bilaspur",
+                "state": "Chhattisgarh",
+                "country": "IND",
+                "areaCode": "495001",
+                "area_code": "495001"
+              }
+            }
+          },
+          "type": "Delivery",
+          "provider_id": "62b42dc426b83e2a358464e2"
+        }
+      ],
+      "payment": {
+        "type": "POST-FULFILLMENT",
+        "collected_by": "BPP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/ondc-withholding_amount": 0,
+        "@ondc/org/ondc-return_window": 0,
+        "@ondc/org/ondc-settlement_basis": "Collection",
+        "@ondc/org/ondc-settlement_window": "PT2D"
+      }
+    }
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407354202"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407354202"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_cancel.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_cancel.json
@@ -1,0 +1,56 @@
+{
+  "_id": {
+    "$oid": "63441a5354e61494687f148e"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_cancel",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_cancel",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "0ace066c-b72c-4192-a019-31402ae1ded5",
+    "timestamp": "2022-10-10T13:12:51.470Z",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api"
+  },
+  "message": {
+    "order": {
+      "id": "31cc2734-807c-4af2-bdf2-df142135b02d",
+      "status": "Cancelled",
+      "tags": {
+        "cancellation_reason_id": "001"
+      }
+    }
+  },
+  "response": {
+    "context": null,
+    "message": {
+      "ack": {
+        "status": "ACK"
+      }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665407571\",expires=\"1665493971\",headers=\"(created) (expires) digest\",signature=\"fR9zfLu3mY19wxSOqnTi6ZRVq2Cfhx7AyIbLdugP/2btVi51woNirGLQvL2cs9C3MpbKiKlmAC3VaIDEpsGLCw==\"",
+    "signing_string": "(created): 1665407571\n(expires): 1665493971\ndigest: BLAKE-512=yIpVGifKdOg5CHe6IRW8q1ii9Tu/ULGiPfheWVR0rAPmK8bKgEyfjcp8k5nioNOyTgwIdtBseWj+cn34jgQ9fQ=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407571665"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407571665"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_confirm.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_confirm.json
@@ -1,0 +1,193 @@
+{
+  "_id": {
+    "$oid": "6344199454e61494687f145c"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_confirm",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_confirm",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "e7e5d087-de5b-4a4a-bd9e-f95799ba84d1",
+    "timestamp": "2022-10-10T13:09:40.055Z",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "descriptor": {
+          "name": "Nivea Shop"
+        }
+      },
+      "provider_location": {
+        "id": "62b42dc426b83e2a358464e2"
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "fulfillment_id": "Fulfillment1",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330"
+        },
+        "breakup": [
+          {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "@ondc/org/item_id": "43001177440483",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "255.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
+          }
+        ],
+        "ttl": ""
+      },
+      "fulfillments": [
+        {
+          "id": "Fulfillment1",
+          "type": "Delivery",
+          "provider_id": "ondc-nivea",
+          "@ondc/org/provider_name": "Manual",
+          "tracking": false,
+          "state": {
+            "descriptor": {
+              "name": "Pending",
+              "code": "pending"
+            }
+          },
+          "end": {
+            "location": {
+              "address": {
+                "door": "modi kirana",
+                "building": "modi kirana",
+                "name": "agam.dubey",
+                "locality": "Agam Dubey",
+                "city": "Bilaspur",
+                "country": "IND",
+                "area_code": "495001",
+                "street": "my street"
+              },
+              "gps": "22.0884760000001, 82.1389140000001"
+            },
+            "contact": {
+              "phone": "9399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "instructions": {
+              "name": "status for drop",
+              "short_desc": "static description"
+            }
+          },
+          "customer": {
+            "contact": {
+              "phone": "9399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "person": {
+              "name": "agam.dubey"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/withholding_amount": "0.0",
+        "@ondc/org/return_window": "0",
+        "@ondc/org/settlement_basis": "Collection",
+        "@ondc/org/settlement_window": "P2D",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "9908112021",
+            "settlement_ifsc_code": "KKBK0000261"
+          }
+        ],
+        "params": {
+          "transaction_id": "ONDC-426281de-010b-4d23-8fb1-77661e37be68-1",
+          "amount": "330",
+          "currency": "INR"
+        }
+      },
+      "created_at": "2022-10-10T13:09:40.048Z",
+      "id": "31cc2734-807c-4af2-bdf2-df142135b02d",
+      "state": "Accepted",
+      "billing": {
+        "name": "Agam Dubey",
+        "address": {
+          "door": "modi kirana",
+          "building": "modi kirana",
+          "name": "Agam Dubey",
+          "locality": "Agam Dubey",
+          "city": "Bilaspur",
+          "country": "IND",
+          "area_code": "495001",
+          "street": "my street"
+        },
+        "phone": "9399452347",
+        "email": "agam.dubey@schbang.com",
+        "tax_number": "",
+        "created_at": "2022-10-10T13:09:40.055Z",
+        "updated_at": "2022-10-10T13:09:40.055Z"
+      },
+      "update_at": "2022-10-10T13:09:40.055Z"
+    }
+  },
+  "response": {
+    "context": null,
+    "message": {
+      "ack": {
+        "status": "ACK"
+      }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665407380\",expires=\"1665493780\",headers=\"(created) (expires) digest\",signature=\"dvNypzgQ0hFo/wAmqXGkYm15tTuAbnBnZqDBucnAeQEl0cdgRo0pqGckl4rwgLFAi1uLgKm8R4BjZJAMVWpUAQ==\"",
+    "signing_string": "(created): 1665407380\n(expires): 1665493780\ndigest: BLAKE-512=G/zyhbs7d3tiNZENCKZVT8JR4nO9k2pao0e6xHrPPkqM3425hQMj0U/c4HoWNswGDgiI7HJHBH8EuFtnBlO/Zw=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407380273"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407380273"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_init.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_init.json
@@ -1,0 +1,179 @@
+{
+  "_id": {
+    "$oid": "6344197c54e61494687f1433"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_init",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_init",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "2d28e536-5681-4c70-a408-e17b5e0f1e36",
+    "timestamp": "2022-10-10T13:09:15.986Z",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "descriptor": {
+          "name": "Nivea Shop"
+        }
+      },
+      "provider_location": {
+        "id": "62b42dc426b83e2a358464e2"
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "fulfillment_id": "Fulfillment1",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330"
+        },
+        "breakup": [
+          {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "@ondc/org/item_id": "43001177440483",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "255.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
+          }
+        ],
+        "ttl": "P24H"
+      },
+      "fulfillments": [
+        {
+          "id": "Fulfillment1",
+          "type": "Delivery",
+          "provider_id": "ondc-nivea",
+          "tracking": false,
+          "end": {
+            "location": {
+              "address": {
+                "door": "modi kirana",
+                "building": "modi kirana",
+                "name": "agam.dubey",
+                "locality": "Agam Dubey",
+                "city": "Bilaspur",
+                "country": "IND",
+                "area_code": "495001",
+                "street": "my street"
+              },
+              "gps": "22.0884760000001, 82.1389140000001"
+            },
+            "contact": {
+              "phone": "9399452347",
+              "email": "agam.dubey@schbang.com"
+            }
+          },
+          "customer": {
+            "contact": {
+              "phone": "9399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "person": {
+              "name": "agam.dubey"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "NOT-PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/withholding_amount": "0.0",
+        "@ondc/org/return_window": "0",
+        "@ondc/org/settlement_basis": "Collection",
+        "@ondc/org/settlement_window": "P2D",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "9908112021",
+            "settlement_ifsc_code": "KKBK0000261"
+          }
+        ],
+        "params": {
+          "amount": "330",
+          "currency": "INR"
+        }
+      },
+      "created_at": "2022-10-10T13:09:15.986Z",
+      "billing": {
+        "name": "Agam Dubey",
+        "address": {
+          "door": "modi kirana",
+          "building": "modi kirana",
+          "name": "Agam Dubey",
+          "locality": "Agam Dubey",
+          "city": "Bilaspur",
+          "country": "IND",
+          "area_code": "495001",
+          "street": "my street"
+        },
+        "phone": "9399452347",
+        "email": "agam.dubey@schbang.com",
+        "tax_number": "",
+        "created_at": "2022-10-10T13:09:15.986Z",
+        "updated_at": "2022-10-10T13:09:15.986Z"
+      },
+      "update_at": "2022-10-10T13:09:15.986Z"
+    }
+  },
+  "response": {
+    "context": null,
+    "message": {
+      "ack": {
+        "status": "ACK"
+      }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665407355\",expires=\"1665493755\",headers=\"(created) (expires) digest\",signature=\"vK0+LQxT79JlPKuAGMiC/10q5GM5AeWHTxq52aM4tl8aOeQVck5qBfmE/3t+mxPm5izCXiCL6eslC6t7SpsnDQ==\"",
+    "signing_string": "(created): 1665407355\n(expires): 1665493755\ndigest: BLAKE-512=HBRx/Vfu+d+xvXZ6z5eWA/MylmD1ZoEEBUvDczRenYwKMDav/gKaITxsIgjKB1L2hSZy5yOhE2b97aRllegQmA=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407356186"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407356186"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_search.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_search.json
@@ -1,0 +1,416 @@
+{
+  "_id": {
+    "$oid": "6344191054e61494687f13ae"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_search",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_search",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "712c4d52-12b6-410a-8437-bbd485521411",
+    "timestamp": "2022-10-10T13:07:28.693Z",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "bpp_id": "ondc.niveashop.in"
+  },
+  "message": {
+    "catalog": {
+      "bpp/descriptor": {
+        "name": "Nivea Shop"
+      },
+      "bpp/providers": [
+        {
+          "id": "62b42dc426b83e2a358464e2",
+          "descriptor": {
+            "name": "Nivea Shop",
+            "symbol": "nivea symbol here",
+            "short_desc": "Nivea Shop",
+            "long_desc": "Nivea Shop",
+            "images": [
+              "https://cdn.shopify.com/s/files/1/0481/5621/3409/files/new-nivea-logo-200-150_e8433df7-ec18-4373-b833-2868d736d1eb_200x150.png?v=1643998222"
+            ]
+          },
+          "items": [
+            {
+              "id": "43001177440483",
+              "descriptor": {
+                "name": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  400ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644"
+                ],
+                "short_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume",
+                "long_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "255.00",
+                "maximum_value": "255.00"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  400ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001177473251",
+              "descriptor": {
+                "name": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  200ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644"
+                ],
+                "short_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume",
+                "long_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "208.00",
+                "maximum_value": "208.00"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  200ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001178816739",
+              "descriptor": {
+                "name": "Body Lotion - Aloe Hydration (Normal skin) |  400ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration.jpg?v=1655790662",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration.jpg?v=1655790662"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
+                "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "219",
+                "maximum_value": "219"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) |  400ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001178849507",
+              "descriptor": {
+                "name": "Body Lotion - Aloe Hydration (Normal skin) |  600ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-600ml-min.jpg?v=1655790662",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-600ml-min.jpg?v=1655790662"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
+                "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "335",
+                "maximum_value": "335"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) |  600ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001178882275",
+              "descriptor": {
+                "name": "Body Lotion - Aloe Hydration (Normal skin) |  200ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-200ml-min.jpg?v=1655790662",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-200ml-min.jpg?v=1655790662"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
+                "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "188",
+                "maximum_value": "188"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) |  200ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001183011043",
+              "descriptor": {
+                "name": "Body Lotion- Aloe Protection with SPF 15 |  200ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15.jpg?v=1655790698",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15.jpg?v=1655790698"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera",
+                "long_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "165",
+                "maximum_value": "165"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion- Aloe Protection with SPF 15 |  200ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001190580451",
+              "descriptor": {
+                "name": "Body Lotion - Extra Whitening Cell Repair SPF 15 (All Skin Types)",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/2_5c1c334f-399e-4925-afef-3833a47cf96c.png?v=1655790796",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/2_5c1c334f-399e-4925-afef-3833a47cf96c.png?v=1655790796",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/6.png?v=1655790796",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/1.png?v=1655790796",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/5.png?v=1655790796"
+                ],
+                "short_desc": "The harmful UV-rays of the sun make your skin uneven, dry, rough, flaky and dark. NIVEA Extra Whitening Cell Repair and UV Protect Body Lotion has 50 times* higher Vitamin C concentration that works from deep within, repairs the skin layer by layer and recovers your skin’s white tone. The NIVEA body lotion is perfect for dry skin because as it immediately absorbs into the skin and moisturises it well. Apply immediately after a shower, as your skin’s pores are open and have an increased capacity to absorb moisture.\nBenefits:\n\nReverse the effects of sun damage with NIVEA Extra Whitening Cell Repair Bodylotion\n\nIts Vitamin C extracts and SPF 15 along with its cell repair formula gives you noticeably even toned skin within 14 days of regular usage\nGives you Smoother Skin - Get visibly even toned smoother skin\nParaben Free\n\nHow to use:\n\nDispense the body lotion into the palm of your hand\nGently massage the lotion onto your skin\nApply evenly all over the body\nUse daily to give your skin the perfect results\n\nSpecial Ingredients:\nCamu Camu & Vitamin C\nOther Ingredients:\nAqua, C12-15 Alkyl Benzoate, Glycerin, Methylpropanediol, Butyl Methoxydibenzoylmethane, Octocrylene, Phenylbenzimidazole Sulfonic Acid, Cetyl Alcohol, Dimethicone, Glyceryl Glucoside, Glycyrrhiza Glabra Root Extract, Vitis Vinifera Seed Oil, Malpighia Glabra Fruit Juice, Myrciaria Dubia Fruit Juice, Bisabolol, Palmitic Acid, Stearic Acid, Myristic Acid, Arachidic Acid, Oleic Acid, Cetyl Palmitate, Glyceryl Stearate, Tapioca Starch, Sodium Carbomer, Trisodium EDTA, Sodium Ascorbyl Phosphate, Propylene Glycol, Citric Acid, Benzoic Acid, Trideceth-9, Phenoxyethanol, Perfume",
+                "long_desc": "The harmful UV-rays of the sun make your skin uneven, dry, rough, flaky and dark. NIVEA Extra Whitening Cell Repair and UV Protect Body Lotion has 50 times* higher Vitamin C concentration that works from deep within, repairs the skin layer by layer and recovers your skin’s white tone. The NIVEA body lotion is perfect for dry skin because as it immediately absorbs into the skin and moisturises it well. Apply immediately after a shower, as your skin’s pores are open and have an increased capacity to absorb moisture.\nBenefits:\n\nReverse the effects of sun damage with NIVEA Extra Whitening Cell Repair Bodylotion\n\nIts Vitamin C extracts and SPF 15 along with its cell repair formula gives you noticeably even toned skin within 14 days of regular usage\nGives you Smoother Skin - Get visibly even toned smoother skin\nParaben Free\n\nHow to use:\n\nDispense the body lotion into the palm of your hand\nGently massage the lotion onto your skin\nApply evenly all over the body\nUse daily to give your skin the perfect results\n\nSpecial Ingredients:\nCamu Camu & Vitamin C\nOther Ingredients:\nAqua, C12-15 Alkyl Benzoate, Glycerin, Methylpropanediol, Butyl Methoxydibenzoylmethane, Octocrylene, Phenylbenzimidazole Sulfonic Acid, Cetyl Alcohol, Dimethicone, Glyceryl Glucoside, Glycyrrhiza Glabra Root Extract, Vitis Vinifera Seed Oil, Malpighia Glabra Fruit Juice, Myrciaria Dubia Fruit Juice, Bisabolol, Palmitic Acid, Stearic Acid, Myristic Acid, Arachidic Acid, Oleic Acid, Cetyl Palmitate, Glyceryl Stearate, Tapioca Starch, Sodium Carbomer, Trisodium EDTA, Sodium Ascorbyl Phosphate, Propylene Glycol, Citric Acid, Benzoic Acid, Trideceth-9, Phenoxyethanol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "125",
+                "maximum_value": "125"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Extra Whitening Cell Repair SPF 15 (All Skin Types)",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001197101283",
+              "descriptor": {
+                "name": "Body Lotion - Aloe Hydration (Normal skin) | 400ml-MYOC",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration_be2df4c8-e10e-4ddd-bbd7-06b6735acc67.jpg?v=1655790881",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration_be2df4c8-e10e-4ddd-bbd7-06b6735acc67.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_3e792509-c84a-4465-8d99-123ccdffeb06.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_6_22310696-4808-4e70-88e6-e8304657118b.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_7_a969ac26-80f2-486c-8bbc-05690eb6409a.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_5_157289e2-6434-43c0-a07a-73bbaf255784.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002479_6_050e07aa-8cd1-4571-894b-c9ee60d23639.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_2_e342a7ea-987c-4981-98f1-8f0d75c9f81a.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_1_8d91ddb6-324a-4ebf-933b-b8160c760ef1.jpg?v=1655790881"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
+                "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "219",
+                "maximum_value": "219"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) | 400ml-MYOC",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001202573539",
+              "descriptor": {
+                "name": "Body Lotion- Aloe Protection with SPF 15 | 200ml-MYOC",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15_9f456c11-c3da-41f5-97f2-f7c739c5d4e1.jpg?v=1655790951",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15_9f456c11-c3da-41f5-97f2-f7c739c5d4e1.jpg?v=1655790951",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/2_5ee05dec-ee85-4fae-b214-ba2482783b56.png?v=1655790951",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/6_557b83a1-ec5c-444e-b9f6-16ce36f35320.png?v=1655790951",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/5_4d7492e7-708c-4692-a9af-406270d3102f.png?v=1655790951",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/1_2722dd7c-c6c3-4476-925d-e8ea8ee6bcb7.png?v=1655790951"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera",
+                "long_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "165",
+                "maximum_value": "165"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion- Aloe Protection with SPF 15 | 200ml-MYOC",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            }
+          ],
+          "ttl": "P24H",
+          "locations": [
+            {
+              "id": "nivea-store-location-1",
+              "gps": "18.9596,72.8496",
+              "address": {
+                "street": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West",
+                "city": "Mumbai",
+                "area_code": "400070",
+                "state": "MH"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "response": {
+    "context": {
+      "domain": "nic2004:52110",
+      "country": "IND",
+      "city": "std:080",
+      "action": "on_search",
+      "core_version": "1.0.0",
+      "bap_id": "buyer-app-preprod.ondc.org",
+      "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+      "bpp_id": "ondc.niveashop.in",
+      "bpp_uri": "https://ondc.niveashop.in/api",
+      "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+      "message_id": "712c4d52-12b6-410a-8437-bbd485521411",
+      "timestamp": "2022-10-10T13:07:28.693Z"
+    },
+    "message": {
+      "ack": {
+        "status": "ACK"
+      }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665407248\",expires=\"1665493648\",headers=\"(created) (expires) digest\",signature=\"t44D5qLXLzWgDbPZ8jGQvx7oWgp5ypuLdf6QaZaI0rGalmco6LxyMfqMm/J4n5AYV09Jswl7+cudYFeDTd0gAw==\"",
+    "signing_string": "(created): 1665407248\n(expires): 1665493648\ndigest: BLAKE-512=HPyJ58vmu2NPH78da7TSGSnFXi/UqGLBDlw60oZD6TPDwKEVv3W3OUefE53WqM+Or3IkhqCwJSBwLr1LRKrEeA=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407248878"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407248878"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_select.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_select.json
@@ -1,0 +1,136 @@
+{
+    "_id": {
+      "$oid": "6332ca1aa0006e42f2402e50"
+    },
+    "transaction_id": "578136214385938600",
+    "store": {
+      "$oid": "62b42dc426b83e2a358464e2"
+    },
+    "action": "on_select",
+    "context": {
+      "domain": "nic2004:52110",
+      "country": "IND",
+      "city": "std:011",
+      "action": "on_select",
+      "timestamp": "2022-09-27T10:02:02.255Z",
+      "ttl": "PT30S",
+      "core_version": "1.0.0",
+      "bap_id": "cloud-adaptor.proteantech.in/kotak",
+      "bap_uri": "https://pilot-gateway-1.beckn.nsdl.co.in/buyer-v4/buyer/adaptor",
+      "bpp_id": "ondc.niveashop.in",
+      "bpp_uri": "https://ondc.niveashop.in/api",
+      "transaction_id": "578136214385938600",
+      "message_id": "609891460901964200"
+    },
+      "message": {
+        "order": {
+          "provider": {
+            "id": "62b42dc426b83e2a358464e2",
+            "descriptor": {
+              "name": "Nivea Shop"
+            }
+          },
+          "items": [
+            {
+              "id": "43001177440483",
+              "fulfillment_id": "Fulfillment1"
+            }
+          ],
+          "fulfillments": [
+            {
+              "id": "Fulfillment1",
+              "@ondc/org/provider_name": "Self Fulfilled",
+              "tracking": false,
+              "@ondc/org/category": "Delivery",
+              "@ondc/org/TAT": "PT5M",
+              "state": {
+                "descriptor": {
+                  "name": "Serviceable"
+                }
+              }
+            }
+          ],
+          "quote": {
+            "price": {
+              "currency": "INR",
+              "value": "330"
+            },
+            "breakup": [
+              {
+                "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+                "@ondc/org/item_id": "43001177440483",
+                "@ondc/org/item_quantity": {
+                  "count": 1
+                },
+                "@ondc/org/title_type": "item",
+                "item": {
+                  "quantity": {
+                    "available": {
+                      "count": "5"
+                    },
+                    "maximum": {
+                      "count": "100"
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "255.00"
+                  }
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "255.00"
+                }
+              },
+              {
+                "@ondc/org/item_id": "Fulfillment1",
+                "title": "Delivery charges",
+                "@ondc/org/title_type": "delivery",
+                "price": {
+                  "currency": "INR",
+                  "value": "75.0"
+                }
+              }
+            ],
+            "ttl": "P24H"
+          }
+        }
+      },
+    "response": {
+      "context": {
+        "domain": "nic2004:52110",
+        "country": "IND",
+        "city": "std:011",
+        "action": "on_select",
+        "core_version": "1.0.0",
+        "bap_id": "cloud-adaptor.proteantech.in/kotak",
+        "bap_uri": "https://pilot-gateway-1.beckn.nsdl.co.in/buyer-v4/buyer/adaptor",
+        "bpp_id": "ondc.niveashop.in",
+        "bpp_uri": "https://ondc.niveashop.in/api",
+        "transaction_id": "578136214385938600",
+        "message_id": "609891460901964200",
+        "timestamp": "2022-09-27T10:02:02.255Z",
+        "ttl": "PT30S"
+      },
+      "message": {
+        "ack": {
+          "status": "ACK"
+        }
+      }
+    },
+    "signature": {
+      "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1664272922\",expires=\"1664359322\",headers=\"(created) (expires) digest\",signature=\"TS5YnTqeBTf0wa5C/SXf4nOZYn1BfHZnmFklAwy3wJ//lyn8YBUcjDFHZESPjVfX7ez0Vv9duA2eHiZOvvUUAA==\"",
+      "signing_string": "(created): 1664272922\n(expires): 1664359322\ndigest: BLAKE-512=uUKD7C92B7xGgN9dpwRnr66r0cOr2k/2kOw2H0uDU7XGPja44DjsqHtG6NeyaHFIdTeIXYtAyz6lY1cR86m6TA=="
+    },
+    "createdAt": {
+      "$date": {
+        "$numberLong": "1664272922348"
+      }
+    },
+    "updatedAt": {
+      "$date": {
+        "$numberLong": "1664272922348"
+      }
+    },
+    "__v": 0
+  }

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_status.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_status.json
@@ -1,0 +1,163 @@
+{
+  "_id": {
+    "$oid": "634419ae54e61494687f1472"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_status",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "c99417e4-df4a-4cbd-a67c-6c874ce29d21",
+    "timestamp": "2022-10-10T13:10:05.830Z",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api"
+  },
+  "message": {
+    "order": {
+      "id": "31cc2734-807c-4af2-bdf2-df142135b02d",
+      "state": "Accepted",
+      "items": [
+        {
+          "id": "43001177440483",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330.00"
+        },
+        "breakup": [
+          {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "price": {
+              "currency": "INR",
+              "value": "255.00",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
+          }
+        ],
+        "ttl": "P24H"
+      },
+      "billing": {
+        "name": "agam.dubey",
+        "address": {
+          "door": "modi kirana",
+          "building": "modi kirana",
+          "name": "agam.dubey",
+          "locality": "Agam Dubey",
+          "city": "Bilaspur",
+          "country": "India",
+          "area_code": "495001",
+          "street": "my street"
+        },
+        "phone": "9399452347",
+        "email": "agam.dubey@schbang.com",
+        "tax_number": "",
+        "created_at": "2022-10-10T13:10:05.829Z",
+        "updated_at": "2022-10-10T13:10:05.829Z"
+      },
+      "fulfillments": [
+        {
+          "id": "Fulfillment1",
+          "type": "Delivery",
+          "provider_id": "ondc-nivea",
+          "tracking": false,
+          "end": {
+            "location": {
+              "address": {
+                "door": "modi kirana",
+                "building": "modi kirana",
+                "name": "Agam Dubey",
+                "locality": "Agam Dubey",
+                "city": "Bilaspur",
+                "country": "India",
+                "area_code": "495001",
+                "street": "my street"
+              }
+            },
+            "contact": {
+              "phone": "9399452347",
+              "email": "agam.dubey@schbang.com"
+            }
+          },
+          "customer": {
+            "contact": {
+              "phone": "9399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "person": {
+              "name": "Agam Dubey"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "NOT-PAID",
+        "params": {
+          "transaction_id": "ONDC-426281de-010b-4d23-8fb1-77661e37be68-1",
+          "amount": "330.00",
+          "currency": "INR"
+        },
+        "collected_by": "BAP",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "9908112021",
+            "settlement_ifsc_code": "KKBK0000261"
+          }
+        ],
+        "@ondc/org/collected_by_status": "Agree",
+        "@ondc/org/settlement_basis": "Collection"
+      }
+    }
+  },
+  "response": {
+    "context": null,
+    "message": {
+      "ack": {
+        "status": "ACK"
+      }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665407405\",expires=\"1665493805\",headers=\"(created) (expires) digest\",signature=\"miSLOGjaPKsxAVYUP/KjhJaj4QgrC8hbLuUhCDddvwDIBVa3OdcG+HNONmRMUqUWQWD668rbHo+3x/WxzlfVCQ==\"",
+    "signing_string": "(created): 1665407405\n(expires): 1665493805\ndigest: BLAKE-512=D7BuYxAh8KyVgzpt8tpxw8gtnciSYcHWyf60qmm6s4VctUk7cYJ7mAfg9s0Eo8FmRqyhnP8XioeHk+gshE0GmA=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407406044"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407406044"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_status_after_cancelling.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_status_after_cancelling.json
@@ -1,0 +1,170 @@
+{
+  "_id": {
+    "$oid": "63441d3654e61494687f1657"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_status",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "62618d3c-f793-42a8-a4ac-a9a8b96f06fe",
+    "timestamp": "2022-10-10T13:25:09.929Z",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api"
+  },
+
+  "message": {
+    "order": {
+      "id": "31cc2734-807c-4af2-bdf2-df142135b02d",
+      "state": "Cancelled",
+      "items": [
+        {
+          "id": "43001177440483",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330.00"
+        },
+        "breakup": [
+          {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "price": {
+              "currency": "INR",
+              "value": "255.00",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
+          }
+        ],
+        "ttl": "P24H"
+      },
+      "billing": {
+        "name": "agam.dubey",
+        "address": {
+          "door": "modi kirana",
+          "building": "modi kirana",
+          "name": "agam.dubey",
+          "locality": "Agam Dubey",
+          "city": "Bilaspur",
+          "country": "India",
+          "area_code": "495001",
+          "street": "my street"
+        },
+        "phone": "9399452347",
+        "email": "agam.dubey@schbang.com",
+        "tax_number": "",
+        "created_at": "2022-10-10T13:25:09.924Z",
+        "updated_at": "2022-10-10T13:25:09.924Z"
+      },
+      "fulfillments": [
+        {
+          "id": "Fulfillment1",
+          "type": "Delivery",
+          "provider_id": "ondc-nivea",
+          "tracking": false,
+          "state": {
+            "descriptor": {
+              "name": "Pending",
+              "code": "Cancelled"
+            }
+          },
+          "end": {
+            "location": {
+              "address": {
+                "door": "modi kirana",
+                "building": "modi kirana",
+                "name": "Agam Dubey",
+                "locality": "Agam Dubey",
+                "city": "Bilaspur",
+                "country": "India",
+                "area_code": "495001",
+                "street": "my street"
+              }
+            },
+            "contact": {
+              "phone": "9399452347",
+              "email": "agam.dubey@schbang.com"
+            }
+          },
+          "customer": {
+            "contact": {
+              "phone": "9399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "person": {
+              "name": "Agam Dubey"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "NOT-PAID",
+        "params": {
+        "transaction_id": "ONDC-426281de-010b-4d23-8fb1-77661e37be68-1",
+          "amount": "330.00",
+          "currency": "INR"
+        },
+        "collected_by": "BAP",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "9908112021",
+            "settlement_ifsc_code": "KKBK0000261"
+          }
+        ],
+        "@ondc/org/collected_by_status": "Agree",
+        "@ondc/org/settlement_basis": "Collection"
+      }
+    }
+  },
+  "response": {
+    "context": null,
+    "message": {
+      "ack": {
+        "status": "ACK"
+      }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665408309\",expires=\"1665494709\",headers=\"(created) (expires) digest\",signature=\"r6XF013nu/aF6HLEeIN6rejY9H3oemAgHZAGenH0khAeLrrMkAS8yLmjPGjGSjN9xeI/oAdaZWWT7vDYAY8UCg==\"",
+    "signing_string": "(created): 1665408309\n(expires): 1665494709\ndigest: BLAKE-512=KrlrM0P8kNqgx5LGKo3bz5N9Rw5b4QAoTj8c1V2AS+LQoASA7Ve/QYosI/22/c3U/da22PcRYOE2UIQhJdkAew=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665408310122"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665408310122"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_support.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_support.json
@@ -1,0 +1,50 @@
+{
+  "_id": {
+    "$oid": "6344585a54e61494687f1cfd"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_support",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_support",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "cf090517-3021-4ada-8d43-fad1051afac8",
+    "timestamp": "2022-10-10T17:37:30.623Z",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api"
+  },
+  "message": {
+    "phone": "+91(0)2262487999"
+  },
+  "response": {
+    "context": null,
+    "message": {
+      "ack": {
+        "status": "ACK"
+      }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665423450\",expires=\"1665509850\",headers=\"(created) (expires) digest\",signature=\"FCtop+hj4Kv1kjSzFOJLz3WiDz0yLaZ1g3EByBEx/1jDjS+zrn05I+tcjJtgMOQ2EhIqsu2T3nT6dJKYMl29Dw==\"",
+    "signing_string": "(created): 1665423450\n(expires): 1665509850\ndigest: BLAKE-512=DrR2OvPGfW9kMB+LkArdBnW7RLHvwVOJHOpYycaRvQXdjd4vtVJvZLQxtciLMGOcZINFnZgMqyDVAIDIIhfWxw=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665423450850"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665423450850"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_track.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_track.json
@@ -1,0 +1,53 @@
+{
+  "_id": {
+    "$oid": "634419c254e61494687f147e"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_track",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_track",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "5db717a6-2790-4c21-872c-57d9947f1135",
+    "timestamp": "2022-10-10T13:10:26.547Z",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api"
+  },
+  "message": {
+    "tracking": {
+      "url": "https://ondc-testing.myshopify.com/65211859171/orders/6595bb6466c714482a7f2dc136ca3f2e/authenticate?key=7b831403657f7352832583797ad1a7ce",
+      "status": "active"
+    }
+  },
+  "response": {
+    "context": null,
+    "message": {
+      "ack": {
+        "status": "ACK"
+      }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665407426\",expires=\"1665493826\",headers=\"(created) (expires) digest\",signature=\"ovkQFGS0BbtrM36VMh1CijpqmgA1IrxWB+aKzm9QG+0sLVJIp7zSbviwDBVc+K9K6ha3+fcqZXW2nrX5zH2vBw==\"",
+    "signing_string": "(created): 1665407426\n(expires): 1665493826\ndigest: BLAKE-512=cHwJhTH+s9z9fqpgZU/sufLpIx5UzuagXLKsOp5gvIUTVwUdqFDBV9HK6Sbps6iDUmKQIjVbYzwQ6TwnB49oag=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407426747"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407426747"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/on_update.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/on_update.json
@@ -1,0 +1,35 @@
+{
+  "_id": {
+    "$oid": "6344191054e61494687f13a4"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_update",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_update",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "62618d3c-f793-42a8-a4ac-a9a8b96f06fe",
+    "timestamp": "2022-10-10T21:31:26.513Z",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api"
+  },
+  "message": {
+    "ack": {
+      "status": "NACK"
+    }
+  },
+  "error": {
+    "type": "CORE-ERROR",
+    "code": "50002",
+    "message": "Updation not possible"
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/search.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/search.json
@@ -1,0 +1,54 @@
+{
+  "_id": {
+    "$oid": "6344191054e61494687f13a4"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "search",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "search",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "712c4d52-12b6-410a-8437-bbd485521411",
+    "timestamp": "2022-10-10T13:07:28.115Z"
+  },
+  "message": {
+    "intent": {
+      "item": {
+        "descriptor": {
+          "name": "body lotion"
+        }
+      },
+      "fulfillment": {
+        "type": "Delivery",
+        "end": {
+          "location": {
+            "gps": "22.0761180000001,82.1584300000001"
+          }
+        }
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+      }
+    }
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407248348"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407248348"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/select.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/select.json
@@ -1,0 +1,66 @@
+{
+  "_id": {
+    "$oid": "6344193754e61494687f13d5"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "select",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "select",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "4a99cf81-5e49-4786-b19d-f1a97f1c61e2",
+    "timestamp": "2022-10-10T13:08:07.213Z",
+    "bpp_id": "ondc.niveashop.in"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "43001177440483",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "locations": [
+          {
+            "id": null
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "22.0761180000001, 82.1584300000001",
+              "address": {
+                "area_code": "495001"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407287445"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407287445"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/status.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/status.json
@@ -1,0 +1,37 @@
+{
+  "_id": {
+    "$oid": "634419ac54e61494687f146a"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "status",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "status",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "c99417e4-df4a-4cbd-a67c-6c874ce29d21",
+    "timestamp": "2022-10-10T13:10:04.442Z",
+    "bpp_id": "ondc.niveashop.in"
+  },
+  "message": {
+    "order_id": "31cc2734-807c-4af2-bdf2-df142135b02d"
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665407404684"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665407404684"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/support.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/support.json
@@ -1,0 +1,38 @@
+{
+  "_id": {
+    "$oid": "6344585a54e61494687f1cf9"
+  },
+  "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "support",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "action": "support",
+    "core_version": "1.0.0",
+    "bap_id": "buyer-app-preprod.ondc.org",
+    "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "message_id": "cf090517-3021-4ada-8d43-fad1051afac8",
+    "timestamp": "2022-10-10T17:37:30.375Z",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api"
+  },
+  "message": {
+    "ref_id": "31cc2734-807c-4af2-bdf2-df142135b02d"
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665423450589"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665423450589"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/BuyerAppPreProdLogs/track.json
+++ b/logs/NiveaShop/BuyerAppPreProdLogs/track.json
@@ -1,0 +1,37 @@
+{
+    "_id": {
+      "$oid": "634419c154e61494687f1476"
+    },
+    "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+    "store": {
+      "$oid": "62b42dc426b83e2a358464e2"
+    },
+    "action": "track",
+    "context": {
+      "domain": "nic2004:52110",
+      "country": "IND",
+      "city": "std:080",
+      "action": "track",
+      "core_version": "1.0.0",
+      "bap_id": "buyer-app-preprod.ondc.org",
+      "bap_uri": "https://buyer-app-preprod.ondc.org/protocol/v1",
+      "transaction_id": "426281de-010b-4d23-8fb1-77661e37be68",
+      "message_id": "5db717a6-2790-4c21-872c-57d9947f1135",
+      "timestamp": "2022-10-10T13:10:25.408Z",
+      "bpp_id": "ondc.niveashop.in"
+    },
+    "message": {
+      "order_id": "31cc2734-807c-4af2-bdf2-df142135b02d"
+    },
+    "createdAt": {
+      "$date": {
+        "$numberLong": "1665407425656"
+      }
+    },
+    "updatedAt": {
+      "$date": {
+        "$numberLong": "1665407425656"
+      }
+    },
+    "__v": 0
+  }

--- a/logs/NiveaShop/MyStoreLogs/confirm.json
+++ b/logs/NiveaShop/MyStoreLogs/confirm.json
@@ -1,158 +1,158 @@
 {
-    "_id": {
-      "$oid": "6332c847a0006e42f2402d08"
-    },
-    "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-    "store": {
-      "$oid": "62b42dc426b83e2a358464e2"
-    },
+  "_id": {
+    "$oid": "63442eab54e61494687f1acc"
+  },
+  "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "confirm",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
     "action": "confirm",
-    "context": {
-      "domain": "nic2004:52110",
-      "country": "IND",
-      "city": "std:080",
-      "core_version": "1.0.0",
-      "action": "confirm",
-      "bap_id": "beta.mystore.in",
-      "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-      "bpp_id": "ondc.niveashop.in",
-      "bpp_uri": "https://ondc.niveashop.in/api",
-      "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-      "message_id": "67001aff-30a1-4281-9221-d4f0dcb275ac",
-      "timestamp": "2022-09-27T09:54:15.242Z",
-      "ttl": "PT30S"
-    },
-    "message": {
-      "order": {
-        "id": "6332c8467169811420fb0bbe",
-        "state": "Created",
-        "provider": {
-          "id": "62b42dc426b83e2a358464e2"
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+    "message_id": "2c4c67c9-e9ce-44f2-9420-56fb9efa7d0d",
+    "timestamp": "2022-10-10T14:39:39.617Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "63442eaa7120b9b462c87620",
+      "state": "Accepted",
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2"
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "Fulfillment1"
+        }
+      ],
+      "billing": {
+        "name": "Agam",
+        "address": {
+          "name": "test address",
+          "city": "Bilaspur",
+          "state": "Chhattisgarh",
+          "country": "IN",
+          "area_code": "495001"
         },
-        "items": [
+        "email": "agam.dubey@schbang.com",
+        "phone": "+919399452347"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330"
+        },
+        "breakup": [
           {
-            "id": "43001177440483",
-            "quantity": {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "@ondc/org/item_id": "43001177440483",
+            "@ondc/org/item_quantity": {
               "count": 1
             },
-            "fulfillment_id": "Fulfillment1"
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "255.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
           }
         ],
-        "billing": {
-          "name": "Agam Dubey",
-          "address": {
-            "name": "My address at my address",
-            "city": "Bilaspur",
-            "state": "Chhattisgarh",
-            "country": "IN",
-            "area_code": "495001"
-          },
-          "email": "agam.dubey@schbang.com",
-          "phone": "+919399452347"
-        },
-        "quote": {
-          "price": {
-            "currency": "INR",
-            "value": "330"
-          },
-          "breakup": [
-            {
-              "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
-              "@ondc/org/item_id": "43001177440483",
-              "@ondc/org/item_quantity": {
-                "count": 1
-              },
-              "@ondc/org/title_type": "item",
-              "price": {
-                "currency": "INR",
-                "value": "255.00"
-              }
-            },
-            {
-              "@ondc/org/item_id": "Fulfillment1",
-              "title": "Delivery charges",
-              "@ondc/org/title_type": "delivery",
-              "price": {
-                "currency": "INR",
-                "value": "75.0"
-              }
-            }
-          ],
-          "ttl": "P24H"
-        },
-        "payment": {
-          "@ondc/org/buyer_app_finder_fee_type": "percent",
-          "@ondc/org/buyer_app_finder_fee_amount": "3",
-          "@ondc/org/withholding_amount": "0.0",
-          "@ondc/org/return_window": "0",
-          "@ondc/org/settlement_basis": "Collection",
-          "@ondc/org/settlement_window": "P2D",
-          "@ondc/org/settlement_details": [
-            {
-              "settlement_counterparty": "seller-app",
-              "settlement_phase": "sale-amount",
-              "settlement_type": "neft",
-              "settlement_bank_account_no": "9908112021",
-              "settlement_ifsc_code": "KKBK0000261"
-            }
-          ],
-          "params": {
-            "transaction_id": "TXN-3SO6_d357",
-            "amount": "330.0000",
-            "currency": "INR"
-          },
-          "type": "ON-ORDER",
-          "status": "PAID",
-          "collected_by": "BAP"
-        },
-        "created_at": "2022-09-27T09:54:14.505Z",
-        "fulfillments": [
+        "ttl": "P24H"
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/withholding_amount": "0.0",
+        "@ondc/org/return_window": "0",
+        "@ondc/org/settlement_basis": "Collection",
+        "@ondc/org/settlement_window": "P2D",
+        "@ondc/org/settlement_details": [
           {
-            "id": "Fulfillment1",
-            "type": "Delivery",
-            "provider_id": "ondc-nivea",
-            "tracking": false,
-            "end": {
-              "location": {
-                "address": {
-                  "door": "undefined",
-                  "building": "undefined",
-                  "name": "agam.dubey",
-                  "locality": "My address at my address",
-                  "city": "Bilaspur",
-                  "country": "IN",
-                  "area_code": "495001",
-                  "street": "undefined"
-                },
-                "gps": "22.097191,82.129388"
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "9908112021",
+            "settlement_ifsc_code": "KKBK0000261"
+          }
+        ],
+        "params": {
+          "transaction_id": "TXN-1bEVHe470",
+          "amount": "330.0000",
+          "currency": "INR"
+        },
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP"
+      },
+      "created_at": "2022-10-10T14:39:38.791Z",
+      "fulfillments": [
+        {
+          "id": "Fulfillment1",
+          "type": "Delivery",
+          "provider_id": "ondc-nivea",
+          "tracking": false,
+          "end": {
+            "location": {
+              "address": {
+                "door": "undefined",
+                "building": "undefined",
+                "name": "agam.dubey",
+                "locality": "test address",
+                "city": "Bilaspur",
+                "country": "IN",
+                "area_code": "495001",
+                "street": "undefined"
               },
-              "contact": {
-                "phone": "+919399452347",
-                "email": "agam.dubey@schbang.com"
-              }
+              "gps": "22.097191,82.129388"
             },
-            "customer": {
-              "contact": {
-                "phone": "+919399452347",
-                "email": "agam.dubey@schbang.com"
-              },
-              "person": {
-                "name": "agam.dubey"
-              }
+            "contact": {
+              "phone": "+919399452347",
+              "email": "agam.dubey@schbang.com"
+            }
+          },
+          "customer": {
+            "contact": {
+              "phone": "+919399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "person": {
+              "name": "agam.dubey"
             }
           }
-        ]
-      }
-    },
-    "createdAt": {
-      "$date": {
-        "$numberLong": "1664272455368"
-      }
-    },
-    "updatedAt": {
-      "$date": {
-        "$numberLong": "1664272455368"
-      }
-    },
-    "__v": 0
-  }
+        }
+      ]
+    }
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665412779853"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665412779853"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/init.json
+++ b/logs/NiveaShop/MyStoreLogs/init.json
@@ -1,97 +1,97 @@
 {
-    "_id": {
-      "$oid": "6332c83fa0006e42f2402cf8"
-    },
-    "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-    "store": {
-      "$oid": "62b42dc426b83e2a358464e2"
-    },
+  "_id": {
+    "$oid": "63442e7954e61494687f1abc"
+  },
+  "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "init",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
     "action": "init",
-    "context": {
-      "domain": "nic2004:52110",
-      "country": "IND",
-      "city": "std:080",
-      "core_version": "1.0.0",
-      "action": "init",
-      "bap_id": "beta.mystore.in",
-      "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-      "bpp_id": "ondc.niveashop.in",
-      "bpp_uri": "https://ondc.niveashop.in/api",
-      "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-      "message_id": "b4795bdc-c6d9-4322-a0fc-82b4572ead03",
-      "timestamp": "2022-09-27T09:54:07.377Z",
-      "ttl": "PT30S"
-    },
-    "message": {
-      "order": {
-        "provider": {
-          "id": "62b42dc426b83e2a358464e2",
-          "locations": [
-            {
-              "id": "nivea-store-location-1"
-            }
-          ]
-        },
-        "items": [
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+    "message_id": "6a2a59b2-f275-42a0-b30b-c8d0551ebb64",
+    "timestamp": "2022-10-10T14:38:49.199Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "locations": [
           {
-            "id": "43001177440483",
-            "quantity": {
-              "count": 1
-            },
-            "fulfillment_id": "Fulfillment1"
+            "id": "nivea-store-location-1"
           }
-        ],
-        "billing": {
-          "name": "Agam Dubey",
-          "address": {
-            "name": "My address at my address",
-            "city": "Bilaspur",
-            "state": "Chhattisgarh",
-            "country": "IN",
-            "area_code": "495001"
+        ]
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "quantity": {
+            "count": 1
           },
-          "email": "agam.dubey@schbang.com",
-          "phone": "+919399452347"
+          "fulfillment_id": "Fulfillment1"
+        }
+      ],
+      "billing": {
+        "name": "Agam",
+        "address": {
+          "name": "test address",
+          "city": "Bilaspur",
+          "state": "Chhattisgarh",
+          "country": "IN",
+          "area_code": "495001"
         },
-        "fulfillments": [
-          {
-            "type": "Delivery",
-            "tracking": false,
-            "end": {
-              "location": {
-                "gps": "22.097191,82.129388",
-                "address": {
-                  "name": "My address at my address",
-                  "city": "Bilaspur",
-                  "state": "Chhattisgarh",
-                  "country": "IN",
-                  "area_code": "495001"
-                }
-              },
-              "contact": {
-                "phone": "+919399452347",
-                "email": "agam.dubey@schbang.com"
+        "email": "agam.dubey@schbang.com",
+        "phone": "+919399452347"
+      },
+      "fulfillments": [
+        {
+          "type": "Delivery",
+          "tracking": false,
+          "end": {
+            "location": {
+              "gps": "22.097191,82.129388",
+              "address": {
+                "name": "test address",
+                "city": "Bilaspur",
+                "state": "Chhattisgarh",
+                "country": "IN",
+                "area_code": "495001"
               }
             },
-            "id": "Fulfillment1"
-          }
-        ],
-        "payment": {
-          "collected_by": "BAP",
-          "@ondc/org/collected_by_status": "Assert",
-          "type": "ON-ORDER"
+            "contact": {
+              "phone": "+919399452347",
+              "email": "agam.dubey@schbang.com"
+            }
+          },
+          "id": "Fulfillment1"
         }
+      ],
+      "payment": {
+        "collected_by": "BAP",
+        "@ondc/org/collected_by_status": "Assert",
+        "type": "ON-ORDER"
       }
-    },
-    "createdAt": {
-      "$date": {
-        "$numberLong": "1664272447619"
-      }
-    },
-    "updatedAt": {
-      "$date": {
-        "$numberLong": "1664272447619"
-      }
-    },
-    "__v": 0
-  }
+    }
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665412729533"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665412729533"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/on_confirm.json
+++ b/logs/NiveaShop/MyStoreLogs/on_confirm.json
@@ -1,12 +1,174 @@
 {
-    "_id": {
-      "$oid": "6332c84ba0006e42f2402d18"
-    },
-    "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-    "store": {
-      "$oid": "62b42dc426b83e2a358464e2"
-    },
+  "_id": {
+    "$oid": "63442eb054e61494687f1adc"
+  },
+  "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_confirm",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
     "action": "on_confirm",
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+    "message_id": "2c4c67c9-e9ce-44f2-9420-56fb9efa7d0d",
+    "timestamp": "2022-10-10T14:39:44.474Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "descriptor": {
+          "name": "Nivea Shop"
+        }
+      },
+      "provider_location": {
+        "id": "62b42dc426b83e2a358464e2"
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "fulfillment_id": "Fulfillment1",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330"
+        },
+        "breakup": [
+          {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "@ondc/org/item_id": "43001177440483",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "255.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
+          }
+        ],
+        "ttl": ""
+      },
+      "fulfillments": [
+        {
+          "id": "Fulfillment1",
+          "type": "Delivery",
+          "provider_id": "ondc-nivea",
+          "@ondc/org/provider_name": "Manual",
+          "tracking": false,
+          "state": {
+            "descriptor": {
+              "name": "Pending",
+              "code": "pending"
+            }
+          },
+          "end": {
+            "location": {
+              "address": {
+                "door": "undefined",
+                "building": "undefined",
+                "name": "agam.dubey",
+                "locality": "test address",
+                "city": "Bilaspur",
+                "country": "IN",
+                "area_code": "495001",
+                "street": "undefined"
+              },
+              "gps": "22.097191,82.129388"
+            },
+            "contact": {
+              "phone": "+919399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "instructions": {
+              "name": "status for drop",
+              "short_desc": "static description"
+            }
+          },
+          "customer": {
+            "contact": {
+              "phone": "+919399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "person": {
+              "name": "agam.dubey"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/withholding_amount": "0.0",
+        "@ondc/org/return_window": "0",
+        "@ondc/org/settlement_basis": "Collection",
+        "@ondc/org/settlement_window": "P2D",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "9908112021",
+            "settlement_ifsc_code": "KKBK0000261"
+          }
+        ],
+        "params": {
+          "transaction_id": "TXN-1bEVHe470",
+          "amount": "330",
+          "currency": "INR"
+        }
+      },
+      "created_at": "2022-10-10T14:39:44.466Z",
+      "id": "63442eaa7120b9b462c87620",
+      "state": "Accepted",
+      "billing": {
+        "name": "Agam",
+        "address": {
+          "door": "undefined",
+          "building": "undefined",
+          "name": "Agam",
+          "locality": "test address",
+          "city": "Bilaspur",
+          "country": "IN",
+          "area_code": "495001",
+          "street": "undefined"
+        },
+        "phone": "+919399452347",
+        "email": "agam.dubey@schbang.com",
+        "tax_number": "",
+        "created_at": "2022-10-10T14:39:44.474Z",
+        "updated_at": "2022-10-10T14:39:44.474Z"
+      },
+      "update_at": "2022-10-10T14:39:44.474Z"
+    }
+  },
+  "response": {
     "context": {
       "domain": "nic2004:52110",
       "country": "IND",
@@ -17,190 +179,30 @@
       "bap_uri": "https://beta.mystore.in/ondc/1.0/",
       "bpp_id": "ondc.niveashop.in",
       "bpp_uri": "https://ondc.niveashop.in/api",
-      "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-      "message_id": "67001aff-30a1-4281-9221-d4f0dcb275ac",
-      "timestamp": "2022-09-27T09:54:19.137Z",
+      "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+      "message_id": "2c4c67c9-e9ce-44f2-9420-56fb9efa7d0d",
+      "timestamp": "2022-10-10T14:39:44.474Z",
       "ttl": "PT30S"
     },
-      "message": {
-        "order": {
-          "provider": {
-            "id": "62b42dc426b83e2a358464e2",
-            "descriptor": {
-              "name": "Nivea Shop"
-            }
-          },
-          "provider_location": {
-            "id": "62b42dc426b83e2a358464e2"
-          },
-          "items": [
-            {
-              "id": "43001177440483",
-              "fulfillment_id": "Fulfillment1",
-              "quantity": {
-                "count": 1
-              }
-            }
-          ],
-          "quote": {
-            "price": {
-              "currency": "INR",
-              "value": "330"
-            },
-            "breakup": [
-              {
-                "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
-                "@ondc/org/item_id": "43001177440483",
-                "@ondc/org/item_quantity": {
-                  "count": 1
-                },
-                "@ondc/org/title_type": "item",
-                "price": {
-                  "currency": "INR",
-                  "value": "255.00"
-                }
-              },
-              {
-                "@ondc/org/item_id": "Fulfillment1",
-                "title": "Delivery charges",
-                "@ondc/org/title_type": "delivery",
-                "price": {
-                  "currency": "INR",
-                  "value": "75.0"
-                }
-              }
-            ],
-            "ttl": ""
-          },
-          "fulfillments": [
-            {
-              "id": "Fulfillment1",
-              "type": "Delivery",
-              "provider_id": "ondc-nivea",
-              "@ondc/org/provider_name": "Manual",
-              "tracking": false,
-              "state": {
-                "descriptor": {
-                  "name": "Pending",
-                  "code": "pending"
-                }
-              },
-              "end": {
-                "location": {
-                  "address": {
-                    "door": "undefined",
-                    "building": "undefined",
-                    "name": "agam.dubey",
-                    "locality": "My address at my address",
-                    "city": "Bilaspur",
-                    "country": "IN",
-                    "area_code": "495001",
-                    "street": "undefined"
-                  },
-                  "gps": "22.097191,82.129388"
-                },
-                "contact": {
-                  "phone": "+919399452347",
-                  "email": "agam.dubey@schbang.com"
-                },
-                "instructions": {
-                  "name": "status for drop",
-                  "short_desc": "static description"
-                }
-              },
-              "customer": {
-                "contact": {
-                  "phone": "+919399452347",
-                  "email": "agam.dubey@schbang.com"
-                },
-                "person": {
-                  "name": "agam.dubey"
-                }
-              }
-            }
-          ],
-          "payment": {
-            "type": "ON-ORDER",
-            "status": "PAID",
-            "collected_by": "BAP",
-            "@ondc/org/buyer_app_finder_fee_type": "percent",
-            "@ondc/org/buyer_app_finder_fee_amount": "3",
-            "@ondc/org/withholding_amount": "0.0",
-            "@ondc/org/return_window": "0",
-            "@ondc/org/settlement_basis": "Collection",
-            "@ondc/org/settlement_window": "P2D",
-            "@ondc/org/settlement_details": [
-              {
-                "settlement_counterparty": "seller-app",
-                "settlement_phase": "sale-amount",
-                "settlement_type": "neft",
-                "settlement_bank_account_no": "9908112021",
-                "settlement_ifsc_code": "KKBK0000261"
-              }
-            ],
-            "params": {
-              "amount": "NaN",
-              "currency": "INR"
-            }
-          },
-          "created_at": "2022-09-27T09:54:19.129Z",
-          "id": "6332c8467169811420fb0bbe",
-          "state": "Accepted",
-          "billing": {
-            "name": "Agam Dubey",
-            "address": {
-              "door": "undefined",
-              "building": "undefined",
-              "name": "Agam Dubey",
-              "locality": "My address at my address",
-              "city": "Bilaspur",
-              "country": "IN",
-              "area_code": "495001",
-              "street": "undefined"
-            },
-            "phone": "+919399452347",
-            "email": "agam.dubey@schbang.com",
-            "tax_number": "",
-            "created_at": "2022-09-27T09:54:19.136Z",
-            "updated_at": "2022-09-27T09:54:19.136Z"
-          }
-        }
-      },
-    "response": {
-      "context": {
-        "domain": "nic2004:52110",
-        "country": "IND",
-        "city": "std:080",
-        "core_version": "1.0.0",
-        "action": "on_confirm",
-        "bap_id": "beta.mystore.in",
-        "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-        "bpp_id": "ondc.niveashop.in",
-        "bpp_uri": "https://ondc.niveashop.in/api",
-        "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-        "message_id": "67001aff-30a1-4281-9221-d4f0dcb275ac",
-        "timestamp": "2022-09-27T09:54:19.137Z",
-        "ttl": "PT30S"
-      },
-      "message": {
-        "ack": {
-          "status": "ACK"
-        }
+    "message": {
+      "ack": {
+        "status": "ACK"
       }
-    },
-    "signature": {
-      "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1664272459\",expires=\"1664358859\",headers=\"(created) (expires) digest\",signature=\"VpS+ULDPhoGZESq7BUFG9EpFySZQW24TOQs88aCB/LWQ/j4xS7560ZXHa4/Jj52CVZN+0MfnJXJKU8e4xVzPAw==\"",
-      "signing_string": "(created): 1664272459\n(expires): 1664358859\ndigest: BLAKE-512=mzFSLMfofY/jvRwOC6Uv41bp7/CyBjw4AtYz4gTFco013r4TM5eIeK2bGaLA7kwVVxpLi+INkdGbxXCZmr4Exw=="
-    },
-    "createdAt": {
-      "$date": {
-        "$numberLong": "1664272459324"
-      }
-    },
-    "updatedAt": {
-      "$date": {
-        "$numberLong": "1664272459324"
-      }
-    },
-    "__v": 0
-  }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665412784\",expires=\"1665499184\",headers=\"(created) (expires) digest\",signature=\"vxPV4H3zONelgrf21M6UW5x5BOneOLxRL1mILiFtW4inB15sRyBr2/PowETVoEshqTQ5UFRK7AbjWJ7t8NpsDQ==\"",
+    "signing_string": "(created): 1665412784\n(expires): 1665499184\ndigest: BLAKE-512=JAd59a/fIJKMWn5ZIZEnF9PUD5BbnHEp/04x5zThQ5QtJ6Regu3ZE5Z5zenuFABWpNxjVWQT5O6Lc2Z8A0iOYw=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665412784694"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665412784694"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/on_init.json
+++ b/logs/NiveaShop/MyStoreLogs/on_init.json
@@ -1,12 +1,160 @@
 {
-    "_id": {
-      "$oid": "6332c842a0006e42f2402d04"
-    },
-    "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-    "store": {
-      "$oid": "62b42dc426b83e2a358464e2"
-    },
+  "_id": {
+    "$oid": "63442e7b54e61494687f1ac8"
+  },
+  "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_init",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
     "action": "on_init",
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+    "message_id": "6a2a59b2-f275-42a0-b30b-c8d0551ebb64",
+    "timestamp": "2022-10-10T14:38:51.230Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "descriptor": {
+          "name": "Nivea Shop"
+        }
+      },
+      "provider_location": {
+        "id": "62b42dc426b83e2a358464e2"
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "fulfillment_id": "Fulfillment1",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330"
+        },
+        "breakup": [
+          {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "@ondc/org/item_id": "43001177440483",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "255.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
+          }
+        ],
+        "ttl": "P24H"
+      },
+      "fulfillments": [
+        {
+          "id": "Fulfillment1",
+          "type": "Delivery",
+          "provider_id": "ondc-nivea",
+          "tracking": false,
+          "end": {
+            "location": {
+              "address": {
+                "door": "undefined",
+                "building": "undefined",
+                "name": "agam.dubey",
+                "locality": "test address",
+                "city": "Bilaspur",
+                "country": "IN",
+                "area_code": "495001",
+                "street": "undefined"
+              },
+              "gps": "22.097191,82.129388"
+            },
+            "contact": {
+              "phone": "+919399452347",
+              "email": "agam.dubey@schbang.com"
+            }
+          },
+          "customer": {
+            "contact": {
+              "phone": "+919399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "person": {
+              "name": "agam.dubey"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "NOT-PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/withholding_amount": "0.0",
+        "@ondc/org/return_window": "0",
+        "@ondc/org/settlement_basis": "Collection",
+        "@ondc/org/settlement_window": "P2D",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "9908112021",
+            "settlement_ifsc_code": "KKBK0000261"
+          }
+        ],
+        "params": {
+          "amount": "330",
+          "currency": "INR"
+        }
+      },
+      "created_at": "2022-10-10T14:38:51.229Z",
+      "billing": {
+        "name": "Agam",
+        "address": {
+          "door": "undefined",
+          "building": "undefined",
+          "name": "Agam",
+          "locality": "test address",
+          "city": "Bilaspur",
+          "country": "IN",
+          "area_code": "495001",
+          "street": "undefined"
+        },
+        "phone": "+919399452347",
+        "email": "agam.dubey@schbang.com",
+        "tax_number": "",
+        "created_at": "2022-10-10T14:38:51.230Z",
+        "updated_at": "2022-10-10T14:38:51.230Z"
+      },
+      "update_at": "2022-10-10T14:38:51.230Z"
+    }
+  },
+  "response": {
     "context": {
       "domain": "nic2004:52110",
       "country": "IND",
@@ -17,178 +165,30 @@
       "bap_uri": "https://beta.mystore.in/ondc/1.0/",
       "bpp_id": "ondc.niveashop.in",
       "bpp_uri": "https://ondc.niveashop.in/api",
-      "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-      "message_id": "b4795bdc-c6d9-4322-a0fc-82b4572ead03",
-      "timestamp": "2022-09-27T09:54:09.816Z",
+      "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+      "message_id": "6a2a59b2-f275-42a0-b30b-c8d0551ebb64",
+      "timestamp": "2022-10-10T14:38:51.230Z",
       "ttl": "PT30S"
     },
-      "message": {
-        "order": {
-          "provider": {
-            "id": "62b42dc426b83e2a358464e2",
-            "descriptor": {
-              "name": "Nivea Shop"
-            }
-          },
-          "provider_location": {
-            "id": "62b42dc426b83e2a358464e2"
-          },
-          "items": [
-            {
-              "id": "43001177440483",
-              "fulfillment_id": "Fulfillment1",
-              "quantity": {
-                "count": 1
-              }
-            }
-          ],
-          "quote": {
-            "price": {
-              "currency": "INR",
-              "value": "330"
-            },
-            "breakup": [
-              {
-                "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
-                "@ondc/org/item_id": "43001177440483",
-                "@ondc/org/item_quantity": {
-                  "count": 1
-                },
-                "@ondc/org/title_type": "item",
-                "price": {
-                  "currency": "INR",
-                  "value": "255.00"
-                }
-              },
-              {
-                "@ondc/org/item_id": "Fulfillment1",
-                "title": "Delivery charges",
-                "@ondc/org/title_type": "delivery",
-                "price": {
-                  "currency": "INR",
-                  "value": "75.0"
-                }
-              }
-            ],
-            "ttl": "P24H"
-          },
-          "fulfillments": [
-            {
-              "id": "Fulfillment1",
-              "type": "Delivery",
-              "provider_id": "ondc-nivea",
-              "tracking": false,
-              "end": {
-                "location": {
-                  "address": {
-                    "door": "undefined",
-                    "building": "undefined",
-                    "name": "agam.dubey",
-                    "locality": "My address at my address",
-                    "city": "Bilaspur",
-                    "country": "IN",
-                    "area_code": "495001",
-                    "street": "undefined"
-                  },
-                  "gps": "22.097191,82.129388"
-                },
-                "contact": {
-                  "phone": "+919399452347",
-                  "email": "agam.dubey@schbang.com"
-                }
-              },
-              "customer": {
-                "contact": {
-                  "phone": "+919399452347",
-                  "email": "agam.dubey@schbang.com"
-                },
-                "person": {
-                  "name": "agam.dubey"
-                }
-              }
-            }
-          ],
-          "payment": {
-            "type": "ON-ORDER",
-            "status": "NOT-PAID",
-            "collected_by": "BAP",
-            "@ondc/org/buyer_app_finder_fee_type": "percent",
-            "@ondc/org/buyer_app_finder_fee_amount": "3",
-            "@ondc/org/withholding_amount": "0.0",
-            "@ondc/org/return_window": "0",
-            "@ondc/org/settlement_basis": "Collection",
-            "@ondc/org/settlement_window": "P2D",
-            "@ondc/org/settlement_details": [
-              {
-                "settlement_counterparty": "seller-app",
-                "settlement_phase": "sale-amount",
-                "settlement_type": "neft",
-                "settlement_bank_account_no": "9908112021",
-                "settlement_ifsc_code": "KKBK0000261"
-              }
-            ],
-            "params": {
-              "amount": "330",
-              "currency": "INR"
-            }
-          },
-          "created_at": "2022-09-27T09:54:09.815Z",
-          "billing": {
-            "name": "Agam Dubey",
-            "address": {
-              "door": "undefined",
-              "building": "undefined",
-              "name": "Agam Dubey",
-              "locality": "My address at my address",
-              "city": "Bilaspur",
-              "country": "IN",
-              "area_code": "495001",
-              "street": "undefined"
-            },
-            "phone": "+919399452347",
-            "email": "agam.dubey@schbang.com",
-            "tax_number": "",
-            "created_at": "2022-09-27T09:54:09.816Z",
-            "updated_at": "2022-09-27T09:54:09.816Z"
-          },
-          "update_at": "2022-09-27T09:54:09.816Z"
-        }
-      },
-    "response": {
-      "context": {
-        "domain": "nic2004:52110",
-        "country": "IND",
-        "city": "std:080",
-        "core_version": "1.0.0",
-        "action": "on_init",
-        "bap_id": "beta.mystore.in",
-        "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-        "bpp_id": "ondc.niveashop.in",
-        "bpp_uri": "https://ondc.niveashop.in/api",
-        "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-        "message_id": "b4795bdc-c6d9-4322-a0fc-82b4572ead03",
-        "timestamp": "2022-09-27T09:54:09.816Z",
-        "ttl": "PT30S"
-      },
-      "message": {
-        "ack": {
-          "status": "ACK"
-        }
+    "message": {
+      "ack": {
+        "status": "ACK"
       }
-    },
-    "signature": {
-      "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1664272449\",expires=\"1664358849\",headers=\"(created) (expires) digest\",signature=\"IsCJp+bi2n3JSP0beXJ5NREtRPE0wyZ3uPavsm07zqnvr1+S8/Bp9NHxg6NhRCHBj6IM4a5FI7RDmmxXN4/bCg==\"",
-      "signing_string": "(created): 1664272449\n(expires): 1664358849\ndigest: BLAKE-512=jkbepAnIK0/uaCg+d/H/5mn4P+Hf37cqZY0pxLkU8k+BHncWV+pWWajVsOGqNUoKNJIc2T8fr6KxVc/bxqA33Q=="
-    },
-    "createdAt": {
-      "$date": {
-        "$numberLong": "1664272450012"
-      }
-    },
-    "updatedAt": {
-      "$date": {
-        "$numberLong": "1664272450012"
-      }
-    },
-    "__v": 0
-  }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665412731\",expires=\"1665499131\",headers=\"(created) (expires) digest\",signature=\"bJv/75oAjN3NAo4OQ07AO8EFES3ZpsI6aSqiYT4/ejmWWjXazebu/O7pDIqXCGLfYFhaJO7LdMUfesw3PcpWBQ==\"",
+    "signing_string": "(created): 1665412731\n(expires): 1665499131\ndigest: BLAKE-512=atXsG8kSwmQB1nYTO/srmP+6602yuK6Co/l9sTBzkH68bK/qZ+dBg1T6kBqE9Ghl4dunPEtvPkSrNTQT78eIIw=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665412731475"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665412731475"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/on_search.json
+++ b/logs/NiveaShop/MyStoreLogs/on_search.json
@@ -1,419 +1,486 @@
 {
-    "_id": {
-      "$oid": "63316616a0006e42f23facb0"
-    },
-    "transaction_id": "f6ccdde5-8b92-4c47-b585-3afe6d9977f7",
-    "store": {
-      "$oid": "62b42dc426b83e2a358464e2"
-    },
+  "_id": {
+    "$oid": "63442e2b54e61494687f1a7a"
+  },
+  "transaction_id": "5427919d-37c5-43d5-beb6-9e01edaa2f4a",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_search",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
     "action": "on_search",
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "transaction_id": "5427919d-37c5-43d5-beb6-9e01edaa2f4a",
+    "message_id": "d7d074b2-ce8d-42df-bdf2-3be435ce1a2b",
+    "timestamp": "2022-10-10T14:37:31.734Z",
+    "ttl": "PT30S",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "bpp_id": "ondc.niveashop.in"
+  },
+  "message": {
+    "catalog": {
+      "bpp/descriptor": {
+        "name": "Nivea Shop"
+      },
+      "bpp/providers": [
+        {
+          "id": "62b42dc426b83e2a358464e2",
+          "descriptor": {
+            "name": "Nivea Shop",
+            "symbol": "nivea symbol here",
+            "short_desc": "Nivea Shop",
+            "long_desc": "Nivea Shop",
+            "images": [
+              "https://cdn.shopify.com/s/files/1/0481/5621/3409/files/new-nivea-logo-200-150_e8433df7-ec18-4373-b833-2868d736d1eb_200x150.png?v=1643998222"
+            ]
+          },
+          "items": [
+            {
+              "id": "43001177440483",
+              "descriptor": {
+                "name": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  400ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644"
+                ],
+                "short_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume",
+                "long_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "255.00",
+                "maximum_value": "255.00"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  400ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001177473251",
+              "descriptor": {
+                "name": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  200ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644"
+                ],
+                "short_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume",
+                "long_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "208.00",
+                "maximum_value": "208.00"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  200ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001178816739",
+              "descriptor": {
+                "name": "Body Lotion - Aloe Hydration (Normal skin) |  400ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration.jpg?v=1655790662",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration.jpg?v=1655790662"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
+                "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "219",
+                "maximum_value": "219"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) |  400ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001178849507",
+              "descriptor": {
+                "name": "Body Lotion - Aloe Hydration (Normal skin) |  600ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-600ml-min.jpg?v=1655790662",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-600ml-min.jpg?v=1655790662"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
+                "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "335",
+                "maximum_value": "335"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) |  600ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001178882275",
+              "descriptor": {
+                "name": "Body Lotion - Aloe Hydration (Normal skin) |  200ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-200ml-min.jpg?v=1655790662",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-200ml-min.jpg?v=1655790662"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
+                "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "188",
+                "maximum_value": "188"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) |  200ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001183011043",
+              "descriptor": {
+                "name": "Body Lotion- Aloe Protection with SPF 15 |  200ml",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15.jpg?v=1655790698",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15.jpg?v=1655790698"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera",
+                "long_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "165",
+                "maximum_value": "165"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion- Aloe Protection with SPF 15 |  200ml",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001190580451",
+              "descriptor": {
+                "name": "Body Lotion - Extra Whitening Cell Repair SPF 15 (All Skin Types)",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/2_5c1c334f-399e-4925-afef-3833a47cf96c.png?v=1655790796",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/2_5c1c334f-399e-4925-afef-3833a47cf96c.png?v=1655790796",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/6.png?v=1655790796",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/1.png?v=1655790796",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/5.png?v=1655790796"
+                ],
+                "short_desc": "The harmful UV-rays of the sun make your skin uneven, dry, rough, flaky and dark. NIVEA Extra Whitening Cell Repair and UV Protect Body Lotion has 50 times* higher Vitamin C concentration that works from deep within, repairs the skin layer by layer and recovers your skin’s white tone. The NIVEA body lotion is perfect for dry skin because as it immediately absorbs into the skin and moisturises it well. Apply immediately after a shower, as your skin’s pores are open and have an increased capacity to absorb moisture.\nBenefits:\n\nReverse the effects of sun damage with NIVEA Extra Whitening Cell Repair Bodylotion\n\nIts Vitamin C extracts and SPF 15 along with its cell repair formula gives you noticeably even toned skin within 14 days of regular usage\nGives you Smoother Skin - Get visibly even toned smoother skin\nParaben Free\n\nHow to use:\n\nDispense the body lotion into the palm of your hand\nGently massage the lotion onto your skin\nApply evenly all over the body\nUse daily to give your skin the perfect results\n\nSpecial Ingredients:\nCamu Camu & Vitamin C\nOther Ingredients:\nAqua, C12-15 Alkyl Benzoate, Glycerin, Methylpropanediol, Butyl Methoxydibenzoylmethane, Octocrylene, Phenylbenzimidazole Sulfonic Acid, Cetyl Alcohol, Dimethicone, Glyceryl Glucoside, Glycyrrhiza Glabra Root Extract, Vitis Vinifera Seed Oil, Malpighia Glabra Fruit Juice, Myrciaria Dubia Fruit Juice, Bisabolol, Palmitic Acid, Stearic Acid, Myristic Acid, Arachidic Acid, Oleic Acid, Cetyl Palmitate, Glyceryl Stearate, Tapioca Starch, Sodium Carbomer, Trisodium EDTA, Sodium Ascorbyl Phosphate, Propylene Glycol, Citric Acid, Benzoic Acid, Trideceth-9, Phenoxyethanol, Perfume",
+                "long_desc": "The harmful UV-rays of the sun make your skin uneven, dry, rough, flaky and dark. NIVEA Extra Whitening Cell Repair and UV Protect Body Lotion has 50 times* higher Vitamin C concentration that works from deep within, repairs the skin layer by layer and recovers your skin’s white tone. The NIVEA body lotion is perfect for dry skin because as it immediately absorbs into the skin and moisturises it well. Apply immediately after a shower, as your skin’s pores are open and have an increased capacity to absorb moisture.\nBenefits:\n\nReverse the effects of sun damage with NIVEA Extra Whitening Cell Repair Bodylotion\n\nIts Vitamin C extracts and SPF 15 along with its cell repair formula gives you noticeably even toned skin within 14 days of regular usage\nGives you Smoother Skin - Get visibly even toned smoother skin\nParaben Free\n\nHow to use:\n\nDispense the body lotion into the palm of your hand\nGently massage the lotion onto your skin\nApply evenly all over the body\nUse daily to give your skin the perfect results\n\nSpecial Ingredients:\nCamu Camu & Vitamin C\nOther Ingredients:\nAqua, C12-15 Alkyl Benzoate, Glycerin, Methylpropanediol, Butyl Methoxydibenzoylmethane, Octocrylene, Phenylbenzimidazole Sulfonic Acid, Cetyl Alcohol, Dimethicone, Glyceryl Glucoside, Glycyrrhiza Glabra Root Extract, Vitis Vinifera Seed Oil, Malpighia Glabra Fruit Juice, Myrciaria Dubia Fruit Juice, Bisabolol, Palmitic Acid, Stearic Acid, Myristic Acid, Arachidic Acid, Oleic Acid, Cetyl Palmitate, Glyceryl Stearate, Tapioca Starch, Sodium Carbomer, Trisodium EDTA, Sodium Ascorbyl Phosphate, Propylene Glycol, Citric Acid, Benzoic Acid, Trideceth-9, Phenoxyethanol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "125",
+                "maximum_value": "125"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Extra Whitening Cell Repair SPF 15 (All Skin Types)",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001192874211",
+              "descriptor": {
+                "name": "Body Cream - Rich Nourishing (Normal to Dry Skin)",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/RICH-NOURISHING-_NORMAL-TO-DRY-SKIN.jpg?v=1655790823",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/RICH-NOURISHING-_NORMAL-TO-DRY-SKIN.jpg?v=1655790823"
+                ],
+                "short_desc": "Benefits:\n\nTreat your skin to the goodness of rich, long-lasting moisturisation with the NEW NIVEA Body Cream\n\nLong Lasting Moisture Care - Keeps your skin moisturised and nourishes from deep within\nEasy Spread-Ability - Its easy-to-spread texture makes application simple\n\nSpecial Ingredients:\nAlmond Oil",
+                "long_desc": "Benefits:\n\nTreat your skin to the goodness of rich, long-lasting moisturisation with the NEW NIVEA Body Cream\n\nLong Lasting Moisture Care - Keeps your skin moisturised and nourishes from deep within\nEasy Spread-Ability - Its easy-to-spread texture makes application simple\n\nSpecial Ingredients:\nAlmond Oil"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "220.00",
+                "maximum_value": "220.00"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Cream - Rich Nourishing (Normal to Dry Skin)",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001197101283",
+              "descriptor": {
+                "name": "Body Lotion - Aloe Hydration (Normal skin) | 400ml-MYOC",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration_be2df4c8-e10e-4ddd-bbd7-06b6735acc67.jpg?v=1655790881",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration_be2df4c8-e10e-4ddd-bbd7-06b6735acc67.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_3e792509-c84a-4465-8d99-123ccdffeb06.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_6_22310696-4808-4e70-88e6-e8304657118b.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_7_a969ac26-80f2-486c-8bbc-05690eb6409a.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_5_157289e2-6434-43c0-a07a-73bbaf255784.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002479_6_050e07aa-8cd1-4571-894b-c9ee60d23639.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_2_e342a7ea-987c-4981-98f1-8f0d75c9f81a.jpg?v=1655790881",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_1_8d91ddb6-324a-4ebf-933b-b8160c760ef1.jpg?v=1655790881"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
+                "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "219",
+                "maximum_value": "219"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) | 400ml-MYOC",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001202573539",
+              "descriptor": {
+                "name": "Body Lotion- Aloe Protection with SPF 15 | 200ml-MYOC",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15_9f456c11-c3da-41f5-97f2-f7c739c5d4e1.jpg?v=1655790951",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15_9f456c11-c3da-41f5-97f2-f7c739c5d4e1.jpg?v=1655790951",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/2_5ee05dec-ee85-4fae-b214-ba2482783b56.png?v=1655790951",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/6_557b83a1-ec5c-444e-b9f6-16ce36f35320.png?v=1655790951",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/5_4d7492e7-708c-4692-a9af-406270d3102f.png?v=1655790951",
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/1_2722dd7c-c6c3-4476-925d-e8ea8ee6bcb7.png?v=1655790951"
+                ],
+                "short_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera",
+                "long_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "165",
+                "maximum_value": "165"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Lotion- Aloe Protection with SPF 15 | 200ml-MYOC",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            },
+            {
+              "id": "43001211519203",
+              "descriptor": {
+                "name": "Body Cream - Rich Nourishing (Normal to Dry Skin) | MYOC",
+                "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/RICH-NOURISHING-_NORMAL-TO-DRY-SKIN_4f719dba-967a-4473-a716-54d88b9c6802.jpg?v=1655791072",
+                "images": [
+                  "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/RICH-NOURISHING-_NORMAL-TO-DRY-SKIN_4f719dba-967a-4473-a716-54d88b9c6802.jpg?v=1655791072"
+                ],
+                "short_desc": "Benefits:\n\nTreat your skin to the goodness of rich, long-lasting moisturisation with the NEW NIVEA Body Cream\n\nLong Lasting Moisture Care - Keeps your skin moisturised and nourishes from deep within\nEasy Spread-Ability - Its easy-to-spread texture makes application simple\n\nSpecial Ingredients:\nAlmond Oil",
+                "long_desc": "Benefits:\n\nTreat your skin to the goodness of rich, long-lasting moisturisation with the NEW NIVEA Body Cream\n\nLong Lasting Moisture Care - Keeps your skin moisturised and nourishes from deep within\nEasy Spread-Ability - Its easy-to-spread texture makes application simple\n\nSpecial Ingredients:\nAlmond Oil"
+              },
+              "price": {
+                "currency": "INR",
+                "value": "220",
+                "maximum_value": "220"
+              },
+              "matched": true,
+              "category_id": "Packaged Commodities",
+              "fulfillment_id": "1",
+              "location_id": "NIVEA_INDIA",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/available_on_cod": true,
+              "@ondc/org/seller_pickup_return": "false",
+              "@ondc/org/time_to_ship": "PT24H",
+              "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "NIVEA India",
+                "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
+                "common_or_generic_name_of_commodity": "Body Cream - Rich Nourishing (Normal to Dry Skin) | MYOC",
+                "net_quantity_or_measure_of_commodity_in_pkg": "1",
+                "month_year_of_manufacture_packing_import": "March, 2022"
+              }
+            }
+          ],
+          "ttl": "P24H",
+          "locations": [
+            {
+              "id": "nivea-store-location-1",
+              "gps": "18.9596,72.8496",
+              "address": {
+                "street": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West",
+                "city": "Mumbai",
+                "area_code": "400070",
+                "state": "MH"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "response": {
     "context": {
       "domain": "nic2004:52110",
       "country": "IND",
       "city": "std:080",
-      "core_version": "1.0.0",
       "action": "on_search",
+      "core_version": "1.0.0",
       "bap_id": "beta.mystore.in",
       "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-      "transaction_id": "f6ccdde5-8b92-4c47-b585-3afe6d9977f7",
-      "message_id": "217bd132-24ea-4108-9a92-7f3867470af9",
-      "timestamp": "2022-09-26T08:43:02.579Z",
-      "ttl": "PT30S",
+      "bpp_id": "ondc.niveashop.in",
       "bpp_uri": "https://ondc.niveashop.in/api",
-      "bpp_id": "ondc.niveashop.in"
+      "transaction_id": "5427919d-37c5-43d5-beb6-9e01edaa2f4a",
+      "message_id": "d7d074b2-ce8d-42df-bdf2-3be435ce1a2b",
+      "timestamp": "2022-10-10T14:37:31.734Z",
+      "ttl": "PT30S"
     },
-
-      "message": {
-        "catalog": {
-          "bpp/descriptor": {
-            "name": "Nivea Shop"
-          },
-          "bpp/providers": [
-            {
-              "id": "62b42dc426b83e2a358464e2",
-              "descriptor": {
-                "name": "Nivea Shop",
-                "symbol": "nivea symbol here",
-                "short_desc": "Nivea Shop",
-                "long_desc": "Nivea Shop",
-                "images": [
-                  "nivea images here of the symbol"
-                ]
-              },
-              "items": [
-                {
-                  "id": "43001177440483",
-                  "descriptor": {
-                    "name": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  400ml",
-                    "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644",
-                    "images": [
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644"
-                    ],
-                    "short_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume",
-                    "long_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume"
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "255.00",
-                    "maximum_value": "255.00"
-                  },
-                  "matched": true,
-                  "category_id": "Packaged Commodities",
-                  "fulfillment_id": "1",
-                  "location_id": "NIVEA_INDIA",
-                  "@ondc/org/returnable": false,
-                  "@ondc/org/cancellable": false,
-                  "@ondc/org/available_on_cod": false,
-                  "@ondc/org/seller_pickup_return": "false",
-                  "@ondc/org/time_to_ship": "PT24H",
-                  "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
-                  "@ondc/org/statutory_reqs_packaged_commodities": {
-                    "manufacturer_or_packer_name": "NIVEA India",
-                    "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
-                    "common_or_generic_name_of_commodity": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  400ml",
-                    "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                    "month_year_of_manufacture_packing_import": "March, 2022"
-                  }
-                },
-                {
-                  "id": "43001177473251",
-                  "descriptor": {
-                    "name": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  200ml",
-                    "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644",
-                    "images": [
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Cherry-Blossom-_-Jojoba-Oil.jpg?v=1655790644"
-                    ],
-                    "short_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume",
-                    "long_desc": "Indulge in the goodness of natural oils in a fast absorbing lotion with the new NIVEA Oil In Lotion Cherry Blossom & Jojoba Oil. The precious natural ingredients and caring oils are blended into a unique lotion that gets quickly absorbed into the skin. The natural oils give you moisturized skin for up to 24 hours with a floral Cherry Blossom fragrance.\nBenefits:\n\nLong Lasting Moisturisation - The formula enriched with natural oils gives you moisturized skin for up to 24 hours\nQuick Absorption - The Jojoba oil is carefully blended in fast absorbing bodylotion\nDelicate Fragrance - The unique lotion has a pleasing floral fragrance of cherry blossom\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nJojoba Oil\nOther Ingredients:\nAqua, Glycerin, Isopropyl Palmitate, Alcohol Denat., Glyceryl Stearate SE, Dimethicone, Carbomer, Sodium Cetearyl Sulfate, Sodium Hydroxide, Trisodium EDTA, Phenoxyethanol, Linalool, Limonene, Benzyl Alcohol, Citronellol, Geraniol, Alpha-Isomethyl Ionone, Perfume"
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "208.00",
-                    "maximum_value": "208.00"
-                  },
-                  "matched": true,
-                  "category_id": "Packaged Commodities",
-                  "fulfillment_id": "1",
-                  "location_id": "NIVEA_INDIA",
-                  "@ondc/org/returnable": false,
-                  "@ondc/org/cancellable": false,
-                  "@ondc/org/available_on_cod": false,
-                  "@ondc/org/seller_pickup_return": "false",
-                  "@ondc/org/time_to_ship": "PT24H",
-                  "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
-                  "@ondc/org/statutory_reqs_packaged_commodities": {
-                    "manufacturer_or_packer_name": "NIVEA India",
-                    "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
-                    "common_or_generic_name_of_commodity": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil |  200ml",
-                    "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                    "month_year_of_manufacture_packing_import": "March, 2022"
-                  }
-                },
-                {
-                  "id": "43001178816739",
-                  "descriptor": {
-                    "name": "Body Lotion - Aloe Hydration (Normal skin) |  400ml",
-                    "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration.jpg?v=1655790662",
-                    "images": [
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration.jpg?v=1655790662"
-                    ],
-                    "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
-                    "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "219",
-                    "maximum_value": "219"
-                  },
-                  "matched": true,
-                  "category_id": "Packaged Commodities",
-                  "fulfillment_id": "1",
-                  "location_id": "NIVEA_INDIA",
-                  "@ondc/org/returnable": false,
-                  "@ondc/org/cancellable": false,
-                  "@ondc/org/available_on_cod": false,
-                  "@ondc/org/seller_pickup_return": "false",
-                  "@ondc/org/time_to_ship": "PT24H",
-                  "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
-                  "@ondc/org/statutory_reqs_packaged_commodities": {
-                    "manufacturer_or_packer_name": "NIVEA India",
-                    "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
-                    "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) |  400ml",
-                    "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                    "month_year_of_manufacture_packing_import": "March, 2022"
-                  }
-                },
-                {
-                  "id": "43001178849507",
-                  "descriptor": {
-                    "name": "Body Lotion - Aloe Hydration (Normal skin) |  600ml",
-                    "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-600ml-min.jpg?v=1655790662",
-                    "images": [
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-600ml-min.jpg?v=1655790662"
-                    ],
-                    "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
-                    "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "335",
-                    "maximum_value": "335"
-                  },
-                  "matched": true,
-                  "category_id": "Packaged Commodities",
-                  "fulfillment_id": "1",
-                  "location_id": "NIVEA_INDIA",
-                  "@ondc/org/returnable": false,
-                  "@ondc/org/cancellable": false,
-                  "@ondc/org/available_on_cod": false,
-                  "@ondc/org/seller_pickup_return": "false",
-                  "@ondc/org/time_to_ship": "PT24H",
-                  "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
-                  "@ondc/org/statutory_reqs_packaged_commodities": {
-                    "manufacturer_or_packer_name": "NIVEA India",
-                    "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
-                    "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) |  600ml",
-                    "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                    "month_year_of_manufacture_packing_import": "March, 2022"
-                  }
-                },
-                {
-                  "id": "43001178882275",
-                  "descriptor": {
-                    "name": "Body Lotion - Aloe Hydration (Normal skin) |  200ml",
-                    "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-200ml-min.jpg?v=1655790662",
-                    "images": [
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-HYDRATION-200ml-min.jpg?v=1655790662"
-                    ],
-                    "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
-                    "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "188",
-                    "maximum_value": "188"
-                  },
-                  "matched": true,
-                  "category_id": "Packaged Commodities",
-                  "fulfillment_id": "1",
-                  "location_id": "NIVEA_INDIA",
-                  "@ondc/org/returnable": false,
-                  "@ondc/org/cancellable": false,
-                  "@ondc/org/available_on_cod": false,
-                  "@ondc/org/seller_pickup_return": "false",
-                  "@ondc/org/time_to_ship": "PT24H",
-                  "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
-                  "@ondc/org/statutory_reqs_packaged_commodities": {
-                    "manufacturer_or_packer_name": "NIVEA India",
-                    "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
-                    "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) |  200ml",
-                    "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                    "month_year_of_manufacture_packing_import": "March, 2022"
-                  }
-                },
-                {
-                  "id": "43001183011043",
-                  "descriptor": {
-                    "name": "Body Lotion- Aloe Protection with SPF 15 |  200ml",
-                    "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15.jpg?v=1655790698",
-                    "images": [
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15.jpg?v=1655790698"
-                    ],
-                    "short_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera",
-                    "long_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera"
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "165",
-                    "maximum_value": "165"
-                  },
-                  "matched": true,
-                  "category_id": "Packaged Commodities",
-                  "fulfillment_id": "1",
-                  "location_id": "NIVEA_INDIA",
-                  "@ondc/org/returnable": false,
-                  "@ondc/org/cancellable": false,
-                  "@ondc/org/available_on_cod": false,
-                  "@ondc/org/seller_pickup_return": "false",
-                  "@ondc/org/time_to_ship": "PT24H",
-                  "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
-                  "@ondc/org/statutory_reqs_packaged_commodities": {
-                    "manufacturer_or_packer_name": "NIVEA India",
-                    "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
-                    "common_or_generic_name_of_commodity": "Body Lotion- Aloe Protection with SPF 15 |  200ml",
-                    "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                    "month_year_of_manufacture_packing_import": "March, 2022"
-                  }
-                },
-                {
-                  "id": "43001190580451",
-                  "descriptor": {
-                    "name": "Body Lotion - Extra Whitening Cell Repair SPF 15 (All Skin Types)",
-                    "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/2_5c1c334f-399e-4925-afef-3833a47cf96c.png?v=1655790796",
-                    "images": [
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/2_5c1c334f-399e-4925-afef-3833a47cf96c.png?v=1655790796",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/6.png?v=1655790796",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/1.png?v=1655790796",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/5.png?v=1655790796"
-                    ],
-                    "short_desc": "The harmful UV-rays of the sun make your skin uneven, dry, rough, flaky and dark. NIVEA Extra Whitening Cell Repair and UV Protect Body Lotion has 50 times* higher Vitamin C concentration that works from deep within, repairs the skin layer by layer and recovers your skin’s white tone. The NIVEA body lotion is perfect for dry skin because as it immediately absorbs into the skin and moisturises it well. Apply immediately after a shower, as your skin’s pores are open and have an increased capacity to absorb moisture.\nBenefits:\n\nReverse the effects of sun damage with NIVEA Extra Whitening Cell Repair Bodylotion\n\nIts Vitamin C extracts and SPF 15 along with its cell repair formula gives you noticeably even toned skin within 14 days of regular usage\nGives you Smoother Skin - Get visibly even toned smoother skin\nParaben Free\n\nHow to use:\n\nDispense the body lotion into the palm of your hand\nGently massage the lotion onto your skin\nApply evenly all over the body\nUse daily to give your skin the perfect results\n\nSpecial Ingredients:\nCamu Camu & Vitamin C\nOther Ingredients:\nAqua, C12-15 Alkyl Benzoate, Glycerin, Methylpropanediol, Butyl Methoxydibenzoylmethane, Octocrylene, Phenylbenzimidazole Sulfonic Acid, Cetyl Alcohol, Dimethicone, Glyceryl Glucoside, Glycyrrhiza Glabra Root Extract, Vitis Vinifera Seed Oil, Malpighia Glabra Fruit Juice, Myrciaria Dubia Fruit Juice, Bisabolol, Palmitic Acid, Stearic Acid, Myristic Acid, Arachidic Acid, Oleic Acid, Cetyl Palmitate, Glyceryl Stearate, Tapioca Starch, Sodium Carbomer, Trisodium EDTA, Sodium Ascorbyl Phosphate, Propylene Glycol, Citric Acid, Benzoic Acid, Trideceth-9, Phenoxyethanol, Perfume",
-                    "long_desc": "The harmful UV-rays of the sun make your skin uneven, dry, rough, flaky and dark. NIVEA Extra Whitening Cell Repair and UV Protect Body Lotion has 50 times* higher Vitamin C concentration that works from deep within, repairs the skin layer by layer and recovers your skin’s white tone. The NIVEA body lotion is perfect for dry skin because as it immediately absorbs into the skin and moisturises it well. Apply immediately after a shower, as your skin’s pores are open and have an increased capacity to absorb moisture.\nBenefits:\n\nReverse the effects of sun damage with NIVEA Extra Whitening Cell Repair Bodylotion\n\nIts Vitamin C extracts and SPF 15 along with its cell repair formula gives you noticeably even toned skin within 14 days of regular usage\nGives you Smoother Skin - Get visibly even toned smoother skin\nParaben Free\n\nHow to use:\n\nDispense the body lotion into the palm of your hand\nGently massage the lotion onto your skin\nApply evenly all over the body\nUse daily to give your skin the perfect results\n\nSpecial Ingredients:\nCamu Camu & Vitamin C\nOther Ingredients:\nAqua, C12-15 Alkyl Benzoate, Glycerin, Methylpropanediol, Butyl Methoxydibenzoylmethane, Octocrylene, Phenylbenzimidazole Sulfonic Acid, Cetyl Alcohol, Dimethicone, Glyceryl Glucoside, Glycyrrhiza Glabra Root Extract, Vitis Vinifera Seed Oil, Malpighia Glabra Fruit Juice, Myrciaria Dubia Fruit Juice, Bisabolol, Palmitic Acid, Stearic Acid, Myristic Acid, Arachidic Acid, Oleic Acid, Cetyl Palmitate, Glyceryl Stearate, Tapioca Starch, Sodium Carbomer, Trisodium EDTA, Sodium Ascorbyl Phosphate, Propylene Glycol, Citric Acid, Benzoic Acid, Trideceth-9, Phenoxyethanol, Perfume"
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "125",
-                    "maximum_value": "125"
-                  },
-                  "matched": true,
-                  "category_id": "Packaged Commodities",
-                  "fulfillment_id": "1",
-                  "location_id": "NIVEA_INDIA",
-                  "@ondc/org/returnable": false,
-                  "@ondc/org/cancellable": false,
-                  "@ondc/org/available_on_cod": false,
-                  "@ondc/org/seller_pickup_return": "false",
-                  "@ondc/org/time_to_ship": "PT24H",
-                  "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
-                  "@ondc/org/statutory_reqs_packaged_commodities": {
-                    "manufacturer_or_packer_name": "NIVEA India",
-                    "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
-                    "common_or_generic_name_of_commodity": "Body Lotion - Extra Whitening Cell Repair SPF 15 (All Skin Types)",
-                    "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                    "month_year_of_manufacture_packing_import": "March, 2022"
-                  }
-                },
-                {
-                  "id": "43001197101283",
-                  "descriptor": {
-                    "name": "Body Lotion - Aloe Hydration (Normal skin) | 400ml-MYOC",
-                    "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration_be2df4c8-e10e-4ddd-bbd7-06b6735acc67.jpg?v=1655790881",
-                    "images": [
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/Aloe-Hydration_be2df4c8-e10e-4ddd-bbd7-06b6735acc67.jpg?v=1655790881",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_3e792509-c84a-4465-8d99-123ccdffeb06.jpg?v=1655790881",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_6_22310696-4808-4e70-88e6-e8304657118b.jpg?v=1655790881",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_7_a969ac26-80f2-486c-8bbc-05690eb6409a.jpg?v=1655790881",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_5_157289e2-6434-43c0-a07a-73bbaf255784.jpg?v=1655790881",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002479_6_050e07aa-8cd1-4571-894b-c9ee60d23639.jpg?v=1655790881",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_2_e342a7ea-987c-4981-98f1-8f0d75c9f81a.jpg?v=1655790881",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/8904256002578_1_8d91ddb6-324a-4ebf-933b-b8160c760ef1.jpg?v=1655790881"
-                    ],
-                    "short_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume",
-                    "long_desc": "Gift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration bodylotion for all day long smooth skin\n\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\nSoothes Skin - The aloe extract relieves dry and irritated skin\n\nHow to use:\n\nStep 1 - Dispense the body lotion into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredients:\nAloe Vera\nOther Ingredients:\nAqua, Glycerin, Alcohol Denat. (4.80% [v/v]), Dicaprylyl Ether, Glyceryl Stearate SE, Isopropyl Palmitate, Cetearyl Alcohol, Aloe Barbadensis Leaf Juice Powder, Dimethicone, Carbomer, Sodium Hydroxide, Sodium Cetearyl Sulfate, Phenoxyethanol, Ethylhexylglycerin, Linalool, Citronellol, Limonene, Alpha-Isomethyl Ionone, Geraniol, Perfume"
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "219",
-                    "maximum_value": "219"
-                  },
-                  "matched": true,
-                  "category_id": "Packaged Commodities",
-                  "fulfillment_id": "1",
-                  "location_id": "NIVEA_INDIA",
-                  "@ondc/org/returnable": false,
-                  "@ondc/org/cancellable": false,
-                  "@ondc/org/available_on_cod": false,
-                  "@ondc/org/seller_pickup_return": "false",
-                  "@ondc/org/time_to_ship": "PT24H",
-                  "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
-                  "@ondc/org/statutory_reqs_packaged_commodities": {
-                    "manufacturer_or_packer_name": "NIVEA India",
-                    "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
-                    "common_or_generic_name_of_commodity": "Body Lotion - Aloe Hydration (Normal skin) | 400ml-MYOC",
-                    "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                    "month_year_of_manufacture_packing_import": "March, 2022"
-                  }
-                },
-                {
-                  "id": "43001202573539",
-                  "descriptor": {
-                    "name": "Body Lotion- Aloe Protection with SPF 15 | 200ml-MYOC",
-                    "symbol": "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15_9f456c11-c3da-41f5-97f2-f7c739c5d4e1.jpg?v=1655790951",
-                    "images": [
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/ALOE-PROTECTION-WITH-SPF-15_9f456c11-c3da-41f5-97f2-f7c739c5d4e1.jpg?v=1655790951",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/2_5ee05dec-ee85-4fae-b214-ba2482783b56.png?v=1655790951",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/6_557b83a1-ec5c-444e-b9f6-16ce36f35320.png?v=1655790951",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/5_4d7492e7-708c-4692-a9af-406270d3102f.png?v=1655790951",
-                      "https://cdn.shopify.com/s/files/1/0652/1185/9171/products/1_2722dd7c-c6c3-4476-925d-e8ea8ee6bcb7.png?v=1655790951"
-                    ],
-                    "short_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera",
-                    "long_desc": "Gift your skin the goodness of NIVEA aloe protection body lotion SPF15 for all day long smooth skin. Enriched with aloe vera extracts, it soothes dry and irritated skin and leaves you with comfortable, soft skin.\nBenefits:\n\nGift your skin the goodness of NIVEA Aloe Hydration Body Lotion for all day long smooth skin\nLong Lasting Hydration - The NIVEA deep moisture serum gives you smoother skin\n\nSPF 15 gives you r skin sun protection and prevents sun damage\n\nHow to use:\n\nStep 1 - Dispense the sunscreen into the palm of your hand Step 2 - Gently massage the lotion onto your skin Step 3 - Apply evenly all over the body Step 4 - Use daily to give your skin the perfect results\nSpecial Ingredient:\nAloe Vera"
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "165",
-                    "maximum_value": "165"
-                  },
-                  "matched": true,
-                  "category_id": "Packaged Commodities",
-                  "fulfillment_id": "1",
-                  "location_id": "NIVEA_INDIA",
-                  "@ondc/org/returnable": false,
-                  "@ondc/org/cancellable": false,
-                  "@ondc/org/available_on_cod": false,
-                  "@ondc/org/seller_pickup_return": "false",
-                  "@ondc/org/time_to_ship": "PT24H",
-                  "@ondc/org/contact_details_consumer_care": "+91(0)2262487999",
-                  "@ondc/org/statutory_reqs_packaged_commodities": {
-                    "manufacturer_or_packer_name": "NIVEA India",
-                    "manufacturer_or_packer_address": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West, Mumbai, Maharashtra 400070",
-                    "common_or_generic_name_of_commodity": "Body Lotion- Aloe Protection with SPF 15 | 200ml-MYOC",
-                    "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                    "month_year_of_manufacture_packing_import": "March, 2022"
-                  }
-                }
-              ],
-              "ttl": "P24H",
-              "locations": [
-                {
-                  "id": "nivea-store-location-1",
-                  "gps": "18.9596,72.8496",
-                  "address": {
-                    "street": "4th Floor, A Wing, Art Guild House, Phoenix Market City, Kurla West",
-                    "city": "Mumbai",
-                    "area_code": "400070",
-                    "state": "MH"
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      },
-    "response": {
-      "context": {
-        "domain": "nic2004:52110",
-        "country": "IND",
-        "city": "std:080",
-        "action": "on_search",
-        "core_version": "0.9.3",
-        "bap_id": "beta.mystore.in",
-        "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-        "bpp_id": "ondc.niveashop.in",
-        "bpp_uri": "https://ondc.niveashop.in/api",
-        "transaction_id": "f6ccdde5-8b92-4c47-b585-3afe6d9977f7",
-        "message_id": "217bd132-24ea-4108-9a92-7f3867470af9",
-        "timestamp": "2022-09-26T08:43:02.579Z",
-        "ttl": "PT30S"
-      },
-      "message": {
-        "ack": {
-          "status": "ACK"
-        }
+    "message": {
+      "ack": {
+        "status": "ACK"
       }
-    },
-    "signature": {
-      "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1664181782\",expires=\"1664268182\",headers=\"(created) (expires) digest\",signature=\"3JJZDqV8joF8YsUpDtnFwnaOFb+9ijNT99Kd3YyUgv2MaEChDuuU9ax/falEMUZ94sFEug54e0Jxl+fTWaEtCA==\"",
-      "signing_string": "(created): 1664181782\n(expires): 1664268182\ndigest: BLAKE-512=OS3h0fKYPJPSSfVM24fcIHHc/JZlwyaEibgAwHX5xhgFo30c9SWEWiDWlH3tZINA3YWmsGuxhzgJxTTP9UWVDA=="
-    },
-    "createdAt": {
-      "$date": {
-        "$numberLong": "1664181782812"
-      }
-    },
-    "updatedAt": {
-      "$date": {
-        "$numberLong": "1664181782812"
-      }
-    },
-    "__v": 0
-  }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665412651\",expires=\"1665499051\",headers=\"(created) (expires) digest\",signature=\"DWAknu8E8SYK0/PCysfuIJJlCcC6UlCT+W+2oxnRIXu1xGvToNsKmwH61pipP/sAwTM3UW03zjkrtBKJJPztDw==\"",
+    "signing_string": "(created): 1665412651\n(expires): 1665499051\ndigest: BLAKE-512=pDzZigKPbZSmh7Bv6xFZM1Y4f6jJM6nO8LavXKRpWuTdevfHbgxxF29y/3BadOXuN8bL5Jj6Yl1Tgwf1TusSqg=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665412651947"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665412651947"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/on_select.json
+++ b/logs/NiveaShop/MyStoreLogs/on_select.json
@@ -1,12 +1,102 @@
 {
-    "_id": {
-      "$oid": "6332c839a0006e42f2402cf1"
-    },
-    "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-    "store": {
-      "$oid": "62b42dc426b83e2a358464e2"
-    },
+  "_id": {
+    "$oid": "63442e5c54e61494687f1aa7"
+  },
+  "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_select",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
     "action": "on_select",
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+    "message_id": "b8fe6d05-e605-494b-bc7f-881516168957",
+    "timestamp": "2022-10-10T14:38:20.336Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "descriptor": {
+          "name": "Nivea Shop"
+        }
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "fulfillment_id": "Fulfillment1"
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "Fulfillment1",
+          "@ondc/org/provider_name": "Self Fulfilled",
+          "tracking": false,
+          "@ondc/org/category": "Delivery",
+          "@ondc/org/TAT": "P15D",
+          "state": {
+            "descriptor": {
+              "name": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330"
+        },
+        "breakup": [
+          {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "@ondc/org/item_id": "43001177440483",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "5"
+                },
+                "maximum": {
+                  "count": "100"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "255.00"
+              }
+            },
+            "price": {
+              "currency": "INR",
+              "value": "255.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
+          }
+        ],
+        "ttl": "P24H"
+      }
+    }
+  },
+  "response": {
     "context": {
       "domain": "nic2004:52110",
       "country": "IND",
@@ -17,120 +107,30 @@
       "bap_uri": "https://beta.mystore.in/ondc/1.0/",
       "bpp_id": "ondc.niveashop.in",
       "bpp_uri": "https://ondc.niveashop.in/api",
-      "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-      "message_id": "d2a82654-e9d6-41f7-816a-691b4811212d",
-      "timestamp": "2022-09-27T09:54:01.521Z",
+      "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+      "message_id": "b8fe6d05-e605-494b-bc7f-881516168957",
+      "timestamp": "2022-10-10T14:38:20.336Z",
       "ttl": "PT30S"
     },
-      "message": {
-        "order": {
-          "provider": {
-            "id": "62b42dc426b83e2a358464e2",
-            "descriptor": {
-              "name": "Nivea Shop"
-            }
-          },
-          "items": [
-            {
-              "id": "43001177440483",
-              "fulfillment_id": "Fulfillment1"
-            }
-          ],
-          "fulfillments": [
-            {
-              "id": "Fulfillment1",
-              "@ondc/org/provider_name": "Self Fulfilled",
-              "tracking": false,
-              "@ondc/org/category": "Delivery",
-              "@ondc/org/TAT": "PT5M",
-              "state": {
-                "descriptor": {
-                  "name": "Serviceable"
-                }
-              }
-            }
-          ],
-          "quote": {
-            "price": {
-              "currency": "INR",
-              "value": "330"
-            },
-            "breakup": [
-              {
-                "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
-                "@ondc/org/item_id": "43001177440483",
-                "@ondc/org/item_quantity": {
-                  "count": 1
-                },
-                "@ondc/org/title_type": "item",
-                "item": {
-                  "quantity": {
-                    "available": {
-                      "count": "5"
-                    },
-                    "maximum": {
-                      "count": "100"
-                    }
-                  },
-                  "price": {
-                    "currency": "INR",
-                    "value": "255.00"
-                  }
-                },
-                "price": {
-                  "currency": "INR",
-                  "value": "255.00"
-                }
-              },
-              {
-                "@ondc/org/item_id": "Fulfillment1",
-                "title": "Delivery charges",
-                "@ondc/org/title_type": "delivery",
-                "price": {
-                  "currency": "INR",
-                  "value": "75.0"
-                }
-              }
-            ],
-            "ttl": "P24H"
-          }
-        }
-      },
-    "response": {
-      "context": {
-        "domain": "nic2004:52110",
-        "country": "IND",
-        "city": "std:080",
-        "core_version": "1.0.0",
-        "action": "on_select",
-        "bap_id": "beta.mystore.in",
-        "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-        "bpp_id": "ondc.niveashop.in",
-        "bpp_uri": "https://ondc.niveashop.in/api",
-        "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-        "message_id": "d2a82654-e9d6-41f7-816a-691b4811212d",
-        "timestamp": "2022-09-27T09:54:01.521Z",
-        "ttl": "PT30S"
-      },
-      "message": {
-        "ack": {
-          "status": "ACK"
-        }
+    "message": {
+      "ack": {
+        "status": "ACK"
       }
-    },
-    "signature": {
-      "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1664272441\",expires=\"1664358841\",headers=\"(created) (expires) digest\",signature=\"dSMnA5vZ2j0VkEwIKk1PMdLYtYuV8gCr/WEzGvxPI9cNvTFjU9ubx6VhT4xOXyQQcLZBgm9rEx+387UpQKbgBQ==\"",
-      "signing_string": "(created): 1664272441\n(expires): 1664358841\ndigest: BLAKE-512=fACs+Zfouvqy4lhnmI5L/FUYCEP6W8s5M3cHh7xYs6M0wmQkh84KCVws8gAnv7ij0WMn/W7vBcvhj9xFIXZcsQ=="
-    },
-    "createdAt": {
-      "$date": {
-        "$numberLong": "1664272441789"
-      }
-    },
-    "updatedAt": {
-      "$date": {
-        "$numberLong": "1664272441789"
-      }
-    },
-    "__v": 0
-  }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665412700\",expires=\"1665499100\",headers=\"(created) (expires) digest\",signature=\"ndFgrGsMdgNi02Q1MCeQPZlQd5X9o37vCG1Xx1y+sW6zvph2Wqdurki+v5rNOSGL3ERKw/dorm+cgsbY21vfBg==\"",
+    "signing_string": "(created): 1665412700\n(expires): 1665499100\ndigest: BLAKE-512=65yKWMYJU2JDACxicolBLpRUJm03uQXi7omyPXX1POXCgPxpjXntA9x95BMn6SoFkU8t6xlbUAzxs2xMFeXzoQ=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665412700522"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665412700522"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/on_status.json
+++ b/logs/NiveaShop/MyStoreLogs/on_status.json
@@ -1,12 +1,150 @@
 {
-    "_id": {
-      "$oid": "6332c884a0006e42f2402d59"
-    },
-    "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-    "store": {
-      "$oid": "62b42dc426b83e2a358464e2"
-    },
+  "_id": {
+    "$oid": "6344370754e61494687f1bc1"
+  },
+  "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_status",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
     "action": "on_status",
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+    "message_id": "4aa27726-3f28-4898-bea2-3e46ffda1bf8",
+    "timestamp": "2022-10-10T15:15:18.798Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "63442eaa7120b9b462c87620",
+      "state": "Accepted",
+      "items": [
+        {
+          "id": "43001177440483",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "330.00"
+        },
+        "breakup": [
+          {
+            "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
+            "price": {
+              "currency": "INR",
+              "value": "255.00",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "Fulfillment1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "75.0"
+            }
+          }
+        ],
+        "ttl": "P24H"
+      },
+      "billing": {
+        "name": "agam.dubey",
+        "address": {
+          "door": "undefined",
+          "building": "undefined",
+          "name": "agam.dubey",
+          "locality": "test address",
+          "city": "Bilaspur",
+          "country": "India",
+          "area_code": "495001",
+          "street": "undefined"
+        },
+        "phone": "+919399452347",
+        "email": "agam.dubey@schbang.com",
+        "tax_number": "",
+        "created_at": "2022-10-10T15:15:18.792Z",
+        "updated_at": "2022-10-10T15:15:18.792Z"
+      },
+      "fulfillments": [
+        {
+          "id": "Fulfillment1",
+          "type": "Delivery",
+          "provider_id": "ondc-nivea",
+          "tracking": false,
+          "state": {
+            "descriptor": {
+              "name": "Pending",
+              "code": "Pending"
+            }
+          },
+          "end": {
+            "location": {
+              "address": {
+                "door": "undefined",
+                "building": "undefined",
+                "name": "Agam",
+                "locality": "test address",
+                "city": "Bilaspur",
+                "country": "India",
+                "area_code": "495001",
+                "street": "undefined"
+              }
+            },
+            "contact": {
+              "phone": "+919399452347",
+              "email": "agam.dubey@schbang.com"
+            }
+          },
+          "customer": {
+            "contact": {
+              "phone": "+919399452347",
+              "email": "agam.dubey@schbang.com"
+            },
+            "person": {
+              "name": "Agam"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "NOT-PAID",
+        "params": {
+          "transaction_id": "TXN-1bEVHe470",
+          "amount": "330.00",
+          "currency": "INR"
+        },
+        "collected_by": "BAP",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "9908112021",
+            "settlement_ifsc_code": "KKBK0000261"
+          }
+        ],
+        "@ondc/org/collected_by_status": "Agree",
+        "@ondc/org/settlement_basis": "Collection"
+      }
+    }
+  },
+  "response": {
     "context": {
       "domain": "nic2004:52110",
       "country": "IND",
@@ -17,178 +155,30 @@
       "bap_uri": "https://beta.mystore.in/ondc/1.0/",
       "bpp_id": "ondc.niveashop.in",
       "bpp_uri": "https://ondc.niveashop.in/api",
-      "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-      "message_id": "a49298f8-6392-493d-8f9a-45a4d0ad8521",
-      "timestamp": "2022-09-27T09:55:16.125Z",
+      "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+      "message_id": "4aa27726-3f28-4898-bea2-3e46ffda1bf8",
+      "timestamp": "2022-10-10T15:15:18.798Z",
       "ttl": "PT30S"
     },
     "message": {
-      "context": {
-        "domain": "nic2004:52110",
-        "country": "IND",
-        "city": "std:080",
-        "core_version": "1.0.0",
-        "action": "on_status",
-        "bap_id": "beta.mystore.in",
-        "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-        "bpp_id": "ondc.niveashop.in",
-        "bpp_uri": "https://ondc.niveashop.in/api",
-        "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-        "message_id": "a49298f8-6392-493d-8f9a-45a4d0ad8521",
-        "timestamp": "2022-09-27T09:55:16.125Z",
-        "ttl": "PT30S"
-      },
-      "message": {
-        "order": {
-          "id": "6332c8467169811420fb0bbe",
-          "state": "Accepted",
-          "items": [
-            {
-              "id": "43001177440483",
-              "quantity": {
-                "count": 1
-              }
-            }
-          ],
-          "quote": {
-            "price": {
-              "currency": "INR",
-              "value": "330.00"
-            },
-            "breakup": [
-              {
-                "title": "Body Lotion - Oil in Lotion Cherry Blossom & Jojoba Oil - 400ml",
-                "price": {
-                  "currency": "INR",
-                  "value": "255.00",
-                  "@ondc/org/item_quantity": {
-                    "count": 1
-                  }
-                }
-              },
-              {
-                "@ondc/org/item_id": "Fulfillment1",
-                "title": "Delivery charges",
-                "@ondc/org/title_type": "delivery",
-                "price": {
-                  "currency": "INR",
-                  "value": "75.0"
-                }
-              }
-            ],
-            "ttl": "P24H"
-          },
-          "billing": {
-            "name": "agam.dubey",
-            "address": {
-              "door": "undefined",
-              "building": "undefined",
-              "name": "agam.dubey",
-              "locality": "My address at my address",
-              "city": "Bilaspur",
-              "country": "India",
-              "area_code": "495001",
-              "street": "undefined"
-            },
-            "phone": "+919399452347",
-            "email": "agam.dubey@schbang.com",
-            "tax_number": "",
-            "created_at": "2022-09-27T09:55:16.125Z",
-            "updated_at": "2022-09-27T09:55:16.125Z"
-          },
-          "fulfillments": [
-            {
-              "id": "Fulfillment1",
-              "type": "Delivery",
-              "provider_id": "ondc-nivea",
-              "tracking": false,
-              "end": {
-                "location": {
-                  "address": {
-                    "door": "undefined",
-                    "building": "undefined",
-                    "name": "Agam Dubey",
-                    "locality": "My address at my address",
-                    "city": "Bilaspur",
-                    "country": "India",
-                    "area_code": "495001",
-                    "street": "undefined"
-                  }
-                },
-                "contact": {
-                  "phone": "+919399452347",
-                  "email": "agam.dubey@schbang.com"
-                }
-              },
-              "customer": {
-                "contact": {
-                  "phone": "+919399452347",
-                  "email": "agam.dubey@schbang.com"
-                },
-                "person": {
-                  "name": "Agam Dubey"
-                }
-              }
-            }
-          ],
-          "payment": {
-            "type": "ON-ORDER",
-            "status": "NOT-PAID",
-            "params": {
-              "amount": "405",
-              "currency": "INR"
-            },
-            "collected_by": "BAP",
-            "@ondc/org/settlement_details": [
-              {
-                "settlement_counterparty": "seller-app",
-                "settlement_phase": "sale-amount",
-                "settlement_type": "neft",
-                "settlement_bank_account_no": "9908112021",
-                "settlement_ifsc_code": "KKBK0000261"
-              }
-            ],
-            "@ondc/org/collected_by_status": "Agree",
-            "@ondc/org/settlement_basis": "Collection"
-          }
-        }
+      "ack": {
+        "status": "ACK"
       }
-    },
-    "response": {
-      "context": {
-        "domain": "nic2004:52110",
-        "country": "IND",
-        "city": "std:080",
-        "core_version": "1.0.0",
-        "action": "on_status",
-        "bap_id": "beta.mystore.in",
-        "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-        "bpp_id": "ondc.niveashop.in",
-        "bpp_uri": "https://ondc.niveashop.in/api",
-        "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-        "message_id": "a49298f8-6392-493d-8f9a-45a4d0ad8521",
-        "timestamp": "2022-09-27T09:55:16.125Z",
-        "ttl": "PT30S"
-      },
-      "message": {
-        "ack": {
-          "status": "ACK"
-        }
-      }
-    },
-    "signature": {
-      "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1664272516\",expires=\"1664358916\",headers=\"(created) (expires) digest\",signature=\"0cfdzy6qraWK4PWf/SyFe17HJjOxF5YRILRRYszOY11Zs3EcIQ4fbxllB9Z521d/upyvAruxL3lviWvKpaVbBg==\"",
-      "signing_string": "(created): 1664272516\n(expires): 1664358916\ndigest: BLAKE-512=lY4OgTv9qIrw9Zl4FKRq9Dh5lMdO3SmmpRg05kxmLNKBPZalPihIypNklJE0n26Y8X8Cgd/PvTEePKRkGChSgg=="
-    },
-    "createdAt": {
-      "$date": {
-        "$numberLong": "1664272516310"
-      }
-    },
-    "updatedAt": {
-      "$date": {
-        "$numberLong": "1664272516310"
-      }
-    },
-    "__v": 0
-  }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665414918\",expires=\"1665501318\",headers=\"(created) (expires) digest\",signature=\"QnPhyk/DmiCLAvfA5mPEfI/SgYw0YW3vnn6pTy43h6ib6WYzwfBNNr8icta/LDsWz+OzVGYuNXQH0+YtU+KOBg==\"",
+    "signing_string": "(created): 1665414918\n(expires): 1665501318\ndigest: BLAKE-512=9JSxL/gWeXqBbk++pTJHTBLswjrep5VN0p4HR0BCODYzQkJkKmtETlQhdXSEZ+pr2rqqXzcbEqzx3pIWuDR5kw=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665414919087"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665414919087"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/on_track.json
+++ b/logs/NiveaShop/MyStoreLogs/on_track.json
@@ -1,0 +1,68 @@
+{
+  "_id": {
+    "$oid": "6344375854e61494687f1bcf"
+  },
+  "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "on_track",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
+    "action": "on_track",
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+    "message_id": "edebb8d5-b14b-46bc-b03c-c9045bdfe67b",
+    "timestamp": "2022-10-10T15:16:40.260Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "tracking": {
+      "url": "https://ondc-testing.myshopify.com/65211859171/orders/c4e832f3750abaadfba8539b4d2a1920/authenticate?key=85bc08c53b92e18856f0108203970901",
+      "status": "active"
+    }
+  },
+  "response": {
+    "context": {
+      "domain": "nic2004:52110",
+      "country": "IND",
+      "city": "std:080",
+      "core_version": "1.0.0",
+      "action": "on_track",
+      "bap_id": "beta.mystore.in",
+      "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+      "bpp_id": "ondc.niveashop.in",
+      "bpp_uri": "https://ondc.niveashop.in/api",
+      "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+      "message_id": "edebb8d5-b14b-46bc-b03c-c9045bdfe67b",
+      "timestamp": "2022-10-10T15:16:40.260Z",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "ack": {
+        "status": "ACK"
+      }
+    }
+  },
+  "signature": {
+    "header": "Signature keyId=\"ondc.niveashop.in|c4e02f71-f240-4ae2-94d4-42fc96a706df|ed25519\",algorithm=\"ed25519\",created=\"1665415000\",expires=\"1665501400\",headers=\"(created) (expires) digest\",signature=\"4p0iX92SVUmfUFp9ZMhrWyl8uIYR82tfzYPqGFd8V0HwgRA4X3MQSeZ9eHMADNdb+vLy4ohGji+LgTk4l3aXCQ==\"",
+    "signing_string": "(created): 1665415000\n(expires): 1665501400\ndigest: BLAKE-512=J+SRtqoCDpJGiIV720H6lseJLzG1VHkoHF9IKEHZ0JhM8ES+g2mqRLiRkFF8OKWy584Rz30n4t1mBl650wup5w=="
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665415000489"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665415000489"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/on_update.json
+++ b/logs/NiveaShop/MyStoreLogs/on_update.json
@@ -1,39 +1,36 @@
 {
   "_id": {
-    "$oid": "6344370554e61494687f1bb9"
+    "$oid": "6355194054a51404487g52a9"
   },
   "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
   "store": {
     "$oid": "62b42dc426b83e2a358464e2"
   },
-  "action": "status",
+  "action": "on_update",
   "context": {
     "domain": "nic2004:52110",
     "country": "IND",
     "city": "std:080",
     "core_version": "1.0.0",
-    "action": "status",
+    "action": "on_update",
     "bap_id": "beta.mystore.in",
     "bap_uri": "https://beta.mystore.in/ondc/1.0/",
     "bpp_id": "ondc.niveashop.in",
     "bpp_uri": "https://ondc.niveashop.in/api",
     "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
     "message_id": "4aa27726-3f28-4898-bea2-3e46ffda1bf8",
-    "timestamp": "2022-10-10T15:15:17.317Z",
+    "timestamp": "2022-10-10T18:43:32.158Z",
     "ttl": "PT30S"
   },
   "message": {
-    "order_id": "63442eaa7120b9b462c87620"
-  },
-  "createdAt": {
-    "$date": {
-      "$numberLong": "1665414917524"
+    "ack": {
+      "status": "NACK"
     }
   },
-  "updatedAt": {
-    "$date": {
-      "$numberLong": "1665414917524"
-    }
+  "error": {
+    "type": "CORE-ERROR",
+    "code": "50002",
+    "message": "Updation not possible"
   },
   "__v": 0
 }

--- a/logs/NiveaShop/MyStoreLogs/search.json
+++ b/logs/NiveaShop/MyStoreLogs/search.json
@@ -1,55 +1,55 @@
 {
-    "_id": {
-      "$oid": "63316616a0006e42f23faca6"
-    },
-    "transaction_id": "f6ccdde5-8b92-4c47-b585-3afe6d9977f7",
-    "store": {
-      "$oid": "62b42dc426b83e2a358464e2"
-    },
+  "_id": {
+    "$oid": "63442e2b54e61494687f1a70"
+  },
+  "transaction_id": "5427919d-37c5-43d5-beb6-9e01edaa2f4a",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "search",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
     "action": "search",
-    "context": {
-      "domain": "nic2004:52110",
-      "country": "IND",
-      "city": "std:080",
-      "core_version": "1.0.0",
-      "action": "search",
-      "bap_id": "beta.mystore.in",
-      "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-      "transaction_id": "f6ccdde5-8b92-4c47-b585-3afe6d9977f7",
-      "message_id": "217bd132-24ea-4108-9a92-7f3867470af9",
-      "timestamp": "2022-09-26T08:43:01.824Z",
-      "ttl": "PT30S"
-    },
-    "message": {
-      "intent": {
-        "item": {
-          "descriptor": {
-            "name": "lotion"
-          }
-        },
-        "fulfillment": {
-          "type": "Delivery",
-          "end": {
-            "location": {
-              "gps": "18.9391667,72.8375556"
-            }
-          }
-        },
-        "payment": {
-          "@ondc/org/buyer_app_finder_fee_type": "percent",
-          "@ondc/org/buyer_app_finder_fee_amount": "3"
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "transaction_id": "5427919d-37c5-43d5-beb6-9e01edaa2f4a",
+    "message_id": "d7d074b2-ce8d-42df-bdf2-3be435ce1a2b",
+    "timestamp": "2022-10-10T14:37:31.203Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "intent": {
+      "item": {
+        "descriptor": {
+          "name": "body "
         }
+      },
+      "fulfillment": {
+        "type": "Delivery",
+        "end": {
+          "location": {
+            "gps": "22.097191,82.129388"
+          }
+        }
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3"
       }
-    },
-    "createdAt": {
-      "$date": {
-        "$numberLong": "1664181782108"
-      }
-    },
-    "updatedAt": {
-      "$date": {
-        "$numberLong": "1664181782108"
-      }
-    },
-    "__v": 0
-  }
+    }
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665412651368"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665412651368"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/select.json
+++ b/logs/NiveaShop/MyStoreLogs/select.json
@@ -1,68 +1,68 @@
 {
-    "_id": {
-      "$oid": "6332c838a0006e42f2402cd8"
-    },
-    "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-    "store": {
-      "$oid": "62b42dc426b83e2a358464e2"
-    },
+  "_id": {
+    "$oid": "63442e5b54e61494687f1a9a"
+  },
+  "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+  "store": {
+    "$oid": "62b42dc426b83e2a358464e2"
+  },
+  "action": "select",
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.0.0",
     "action": "select",
-    "context": {
-      "domain": "nic2004:52110",
-      "country": "IND",
-      "city": "std:080",
-      "core_version": "1.0.0",
-      "action": "select",
-      "bap_id": "beta.mystore.in",
-      "bap_uri": "https://beta.mystore.in/ondc/1.0/",
-      "bpp_id": "ondc.niveashop.in",
-      "bpp_uri": "https://ondc.niveashop.in/api",
-      "transaction_id": "b0bd1dc3-10de-48bc-adf9-0c3c67ec37b8",
-      "message_id": "d2a82654-e9d6-41f7-816a-691b4811212d",
-      "timestamp": "2022-09-27T09:54:00.090Z",
-      "ttl": "PT30S"
-    },
-    "message": {
-      "order": {
-        "provider": {
-          "id": "62b42dc426b83e2a358464e2",
-          "locations": [
-            {
-              "id": "nivea-store-location-1"
-            }
-          ]
-        },
-        "items": [
+    "bap_id": "beta.mystore.in",
+    "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+    "bpp_id": "ondc.niveashop.in",
+    "bpp_uri": "https://ondc.niveashop.in/api",
+    "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+    "message_id": "b8fe6d05-e605-494b-bc7f-881516168957",
+    "timestamp": "2022-10-10T14:38:18.899Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "62b42dc426b83e2a358464e2",
+        "locations": [
           {
-            "id": "43001177440483",
-            "quantity": {
-              "count": 1
-            }
+            "id": "nivea-store-location-1"
           }
-        ],
-        "fulfillments": [
-          {
-            "end": {
-              "location": {
-                "gps": "22.097191,82.129388",
-                "address": {
-                  "area_code": "495001"
-                }
+        ]
+      },
+      "items": [
+        {
+          "id": "43001177440483",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "22.097191,82.129388",
+              "address": {
+                "area_code": "495001"
               }
             }
           }
-        ]
-      }
-    },
-    "createdAt": {
-      "$date": {
-        "$numberLong": "1664272440352"
-      }
-    },
-    "updatedAt": {
-      "$date": {
-        "$numberLong": "1664272440352"
-      }
-    },
-    "__v": 0
-  }
+        }
+      ]
+    }
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1665412699166"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1665412699166"
+    }
+  },
+  "__v": 0
+}

--- a/logs/NiveaShop/MyStoreLogs/track.json
+++ b/logs/NiveaShop/MyStoreLogs/track.json
@@ -1,0 +1,39 @@
+{
+    "_id": {
+      "$oid": "6344375754e61494687f1bc7"
+    },
+    "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+    "store": {
+      "$oid": "62b42dc426b83e2a358464e2"
+    },
+    "action": "track",
+    "context": {
+      "domain": "nic2004:52110",
+      "country": "IND",
+      "city": "std:080",
+      "core_version": "1.0.0",
+      "action": "track",
+      "bap_id": "beta.mystore.in",
+      "bap_uri": "https://beta.mystore.in/ondc/1.0/",
+      "bpp_id": "ondc.niveashop.in",
+      "bpp_uri": "https://ondc.niveashop.in/api",
+      "transaction_id": "b4945e79-3946-4d85-a067-4294478b13a8",
+      "message_id": "edebb8d5-b14b-46bc-b03c-c9045bdfe67b",
+      "timestamp": "2022-10-10T15:16:39.187Z",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order_id": "63442eaa7120b9b462c87620"
+    },
+    "createdAt": {
+      "$date": {
+        "$numberLong": "1665414999420"
+      }
+    },
+    "updatedAt": {
+      "$date": {
+        "$numberLong": "1665414999420"
+      }
+    },
+    "__v": 0
+  }


### PR DESCRIPTION
The MyStore buyer app doesn't send a /support call at the moment. 
All the APIs are retested on the buyer reference app, please refer it for /support and /on_support.
Nivea does not accept return and we only have the /on_update implemented for settling amount with the buyer app. For update.target = "item" returns NACK .